### PR TITLE
fix(cli): override package version

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Commit Changelog should parse commits to produce a CHANGELOG.md with an override version: override 1`] = `
+{
+  "changelog": "# Changelog
+All notable changes to this project will be documented in this file.
+## <semverClean>["15.0.0"]</semverClean> (2022-10-01)
+
+",
+  "package": "Version bump: <semverClean>["15.0.0"]</semverClean>",
+  "parsedCommits": {},
+  "semverBump": "override",
+  "semverWeight": 0,
+  "version": "15.0.0",
+  "versionClean": "<semverClean>["15.0.0"]</semverClean>",
+}
+`;
+
 exports[`Commit Changelog should parse commits to produce a CHANGELOG.md: Commit Changelog 1`] = `
 {
   "changelog": "# Changelog

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -4,4 +4,10 @@ describe('Commit Changelog', () => {
   it('should parse commits to produce a CHANGELOG.md', () => {
     expect(commitChangelog({ date: new Date('2022-10-01').toISOString() })).toMatchSnapshot('Commit Changelog');
   });
+
+  it('should parse commits to produce a CHANGELOG.md with an override version', () => {
+    expect(commitChangelog({ overrideVersion: '15.0.0', date: new Date('2022-10-01').toISOString() })).toMatchSnapshot(
+      'override'
+    );
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,10 @@ const commitChangelog = ({
   }
 
   const parsedCommits = parseCommits({ commitPath, prPath, remoteUrl }, { isAllowNonConventionalCommits });
-  const { bump, weight } = semverBump(parsedCommits, { isAllowNonConventionalCommits });
+  const { bump, weight } = semverBump(parsedCommits, {
+    isAllowNonConventionalCommits,
+    isOverrideVersion: overrideVersion !== undefined
+  });
   const { clean: cleanVersion, version } = (overrideVersion && getOverrideVersion(overrideVersion)) || getVersion(bump);
 
   if (isDryRun) {
@@ -46,7 +49,7 @@ const commitChangelog = ({
   }
 
   const changelog = updateChangelog(parsedCommits, cleanVersion, { comparePath, date, isDryRun, remoteUrl });
-  const packageJSON = updatePackage(bump, { isDryRun });
+  const packageJSON = updatePackage((overrideVersion && cleanVersion) || bump, { isDryRun });
 
   if (isCommit && !isDryRun) {
     commitFiles(cleanVersion);

--- a/src/parse.js
+++ b/src/parse.js
@@ -181,12 +181,18 @@ const parseCommits = (
  *
  * @param {{ feat: { commits: Array }, refactor: { commits: Array }, fix: { commits: Array } }} parsedCommits
  * @param {object} options
- * @param {boolean} isAllowNonConventionalCommits
+ * @param {Function} options.getCommitType
+ * @param {boolean} options.isAllowNonConventionalCommits
+ * @param {boolean} options.isOverrideVersion
  * @returns {{bump: ('major'|'minor'|'patch'), weight: number}}
  */
 const semverBump = (
   parsedCommits = {},
-  { getCommitType: getAliasCommitType = getCommitType, isAllowNonConventionalCommits = false } = {}
+  {
+    getCommitType: getAliasCommitType = getCommitType,
+    isAllowNonConventionalCommits = false,
+    isOverrideVersion = false
+  } = {}
 ) => {
   const commitType = getAliasCommitType({ isAllowNonConventionalCommits });
   let weight = 0;
@@ -207,7 +213,7 @@ const semverBump = (
   });
 
   return {
-    bump: (weight >= 100 && 'major') || (weight >= 10 && 'minor') || 'patch',
+    bump: (isOverrideVersion && 'override') || (weight >= 100 && 'major') || (weight >= 10 && 'minor') || 'patch',
     weight
   };
 };

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -7,6 +7,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "cmds.js:168:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
   "files.js:73:    console.info(\` \${updatedBody}\`)",
   "global.js:64:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
-  "index.js:42:    console.info( index.js:56:    console.info(color.NOCOLOR)",
+  "index.js:45:    console.info( index.js:59:    console.info(color.NOCOLOR)",
 ]
 `;


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- fix(cli): override package version

### Notes
- corrects the override option by also updating package.json
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn release --dry-run -o v15.0.0`
1. confirm the console output aligns to a proper override display
```
Dry run CHANGELOG.md output...
Version: v15.0.0
Semver bump: override
Semver weight: XXX

## [15.0.0](https://github.com/XXXX/changelog-light/compare/XXXX...XXXX) (2022-10-28)

...

```

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing