### PR TITLE
feat(cli): release-message, expose default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,33 +36,39 @@ or Yarn
   Usage: changelog [options]
 
   Options:
-    -b, --basic         Keep updates to CHANGELOG.md basic, skip all markdown link
-                        syntax                          [boolean] [default: false]
-    -c, --commit        Commit CHANGELOG.md and package.json with a release commit
-                                                         [boolean] [default: true]
-    -d, --date          CHANGELOG.md release date in the form of a valid date
-                        string. Uses system new Date([your date])
-                                    [string] [default: "2022-10-13T17:51:29.464Z"]
-    -n, --non-cc        Allow non-conventional commits to apply a semver weight
-                        and appear in CHANGELOG.md under a general type
-                        description.                    [boolean] [default: false]
-    -o, --override      Use a version you define.                         [string]
-    -r, --dry-run       Generate CHANGELOG.md sample output
+    -b, --basic            Keep updates to CHANGELOG.md basic, skip all markdown
+                           link syntax                  [boolean] [default: false]
+    -c, --commit           Commit CHANGELOG.md and package.json with a release
+                           commit                        [boolean] [default: true]
+    -d, --date             CHANGELOG.md release date in the form of a valid date
+                           string. Uses system new Date([your date])
+                                    [string] [default: "2022-12-17T02:28:23.456Z"]
+    -n, --non-cc           Allow non-conventional commits to apply a semver weight
+                           and appear in CHANGELOG.md under a general type
+                           description.                 [boolean] [default: false]
+    -o, --override         Use a version you define.                      [string]
+    -r, --dry-run          Generate CHANGELOG.md sample output
                                                         [boolean] [default: false]
-        --commit-path   CHANGELOG.md path used for commits. This will be "joined"
-                        with "remote-url". Defaults to the commits path for
-                        GitHub.                      [string] [default: "commit/"]
-        --compare-path  CHANGELOG.md path used for version comparison. This will
-                        be "joined" with "remote-url". Defaults to the comparison
-                        path for GitHub.            [string] [default: "compare/"]
-        --pr-path       CHANGELOG.md path used for PRs/MRs. This will be "joined"
-                        with "remote-url". Defaults to the PR path for GitHub.
-                                                       [string] [default: "pull/"]
-        --remote-url    Git remote get-url for updating CHANGELOG.md base urls.
-                        This should start with "http". Defaults to "$ git remote
-                        get-url origin"                                   [string]
-    -h, --help          Show help                                        [boolean]
-    -v, --version       Show version number                              [boolean]
+        --commit-path      CHANGELOG.md path used for commits. This will be
+                           "joined" with "remote-url". Defaults to the commits
+                           path for GitHub.          [string] [default: "commit/"]
+        --compare-path     CHANGELOG.md path used for version comparison. This
+                           will be "joined" with "remote-url". Defaults to the
+                           comparison path for GitHub.
+                                                    [string] [default: "compare/"]
+        --pr-path          CHANGELOG.md path used for PRs/MRs. This will be
+                           "joined" with "remote-url". Defaults to the PR path for
+                           GitHub.                     [string] [default: "pull/"]
+        --release-message  A list of prefix release scope commit messages. First
+                           list item is the new commit message prefix, the second
+                           list item searches for the prior release message prefix
+                           for range. [write new, search old]
+                                               [array] [default: "chore(release)"]
+        --remote-url       Git remote get-url for updating CHANGELOG.md base urls.
+                           This should start with "http". Defaults to "$ git
+                           remote get-url origin"                         [string]
+    -h, --help             Show help                                     [boolean]
+    -v, --version          Show version number                           [boolean]
 ```
 ### Using within a project
 Using `changelog-light` within a project requires one primary thing... formatting your commit messages using [conventional commit types](https://www.conventionalcommits.org)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ const {
   'non-cc': isAllowNonConventionalCommits,
   override: overrideVersion,
   'pr-path': prPath,
+  'release-message': releaseTypeScope,
   'remote-url': remoteUrl
 } = yargs
   .usage('Generate a CHANGELOG.md with conventional commit types.\n\nUsage: changelog [options]')
@@ -78,6 +79,12 @@ const {
       'CHANGELOG.md path used for PRs/MRs. This will be "joined" with "remote-url". Defaults to the PR path for GitHub.',
     type: 'string'
   })
+  .option('release-message', {
+    default: 'chore(release)',
+    describe:
+      'A list of prefix release scope commit messages. First list item is the new commit message prefix, the second list item searches for the prior release message prefix for range. [write new, search old]',
+    type: 'array'
+  })
   .option('remote-url', {
     describe:
       'Git remote get-url for updating CHANGELOG.md base urls. This should start with "http". Defaults to "$ git remote get-url origin"',
@@ -88,8 +95,9 @@ const {
  * Set global OPTIONS
  *
  * @type {{comparePath: string, date: string, commitPath: string, isOverrideVersion: boolean,
- *     isAllowNonConventionalCommits: boolean, isDryRun: boolean, remoteUrl: string,
- *     prPath: string, isCommit: boolean, overrideVersion: string|*, isBasic: boolean}}
+ *     isAllowNonConventionalCommits: boolean, releaseTypeScope: string[], isDryRun: boolean,
+ *     remoteUrl: string, prPath: string, isCommit: boolean, overrideVersion: string|*,
+ *     isBasic: boolean}}
  * @private
  */
 OPTIONS._set = {
@@ -103,6 +111,7 @@ OPTIONS._set = {
   isOverrideVersion: overrideVersion !== undefined,
   overrideVersion,
   prPath,
+  releaseTypeScope,
   remoteUrl
 };
 

--- a/src/__tests__/__snapshots__/cmds.test.js.snap
+++ b/src/__tests__/__snapshots__/cmds.test.js.snap
@@ -36,3 +36,24 @@ exports[`Commands should attempt to run commands: commands 1`] = `
   },
 ]
 `;
+
+exports[`Commands should handle multiple formats for releaseTypeScope: releaseTypeScope, multi-list item 1`] = `
+{
+  "commitFiles": "<execSync>["git add ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md && git commit ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md -m \\"chore(release): undefined\\""]</execSync>",
+  "getReleaseCommit": "<execSync>["git log --grep=\\"dolor sit\\" --pretty=oneline -1"]</execSync>",
+}
+`;
+
+exports[`Commands should handle multiple formats for releaseTypeScope: releaseTypeScope, single list item 1`] = `
+{
+  "commitFiles": "<execSync>["git add ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md && git commit ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md -m \\"chore(release): undefined\\""]</execSync>",
+  "getReleaseCommit": "<execSync>["git log --grep=\\"chore(release)\\" --pretty=oneline -1"]</execSync>",
+}
+`;
+
+exports[`Commands should handle multiple formats for releaseTypeScope: releaseTypeScope, string 1`] = `
+{
+  "commitFiles": "<execSync>["git add ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md && git commit ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md -m \\"chore(release): undefined\\""]</execSync>",
+  "getReleaseCommit": "<execSync>["git log --grep=\\"chore(release)\\" --pretty=oneline -1"]</execSync>",
+}
+`;

--- a/src/__tests__/cmds.test.js
+++ b/src/__tests__/cmds.test.js
@@ -1,11 +1,53 @@
 const cmds = require('../cmds');
+const { OPTIONS } = require('../global');
 
 describe('Commands', () => {
   it('should attempt to run commands', () => {
+    const { mockClear } = mockObjectProperty(OPTIONS, {
+      releaseTypeScope: 'chore(release)'
+    });
+
     expect(
       Object.entries(cmds).map(([key, func]) => ({
         [key]: func()
       }))
     ).toMatchSnapshot('commands');
+
+    mockClear();
+  });
+
+  it('should handle multiple formats for releaseTypeScope', () => {
+    // string
+    const { mockClear: strMockClear } = mockObjectProperty(OPTIONS, {
+      releaseTypeScope: 'chore(release)'
+    });
+
+    expect({ commitFiles: cmds.commitFiles(), getReleaseCommit: cmds.getReleaseCommit() }).toMatchSnapshot(
+      'releaseTypeScope, string'
+    );
+
+    strMockClear();
+
+    // single list item
+    const { mockClear: singleItemMockClear } = mockObjectProperty(OPTIONS, {
+      releaseTypeScope: ['chore(release)']
+    });
+
+    expect({ commitFiles: cmds.commitFiles(), getReleaseCommit: cmds.getReleaseCommit() }).toMatchSnapshot(
+      'releaseTypeScope, single list item'
+    );
+
+    singleItemMockClear();
+
+    // multi-list item
+    const { mockClear: multiItemMockClear } = mockObjectProperty(OPTIONS, {
+      releaseTypeScope: ['chore(release)', 'dolor sit', 'lorem ipsum']
+    });
+
+    expect({ commitFiles: cmds.commitFiles(), getReleaseCommit: cmds.getReleaseCommit() }).toMatchSnapshot(
+      'releaseTypeScope, multi-list item'
+    );
+
+    multiItemMockClear();
   });
 });

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -29,17 +29,20 @@ const runCmd = (cmd, { errorMessage = 'Skipping... {0}' } = {}) => {
  * @param {*|string} version
  * @param {object} options
  * @param {string} options.contextPath
- * @param {string} options.releaseTypeScope
+ * @param {string[]|string} options.releaseTypeScope
  * @returns {string}
  */
-const commitFiles = (version, { contextPath, releaseTypeScope = 'chore(release)' } = OPTIONS) =>
-  runCmd(
+const commitFiles = (version, { contextPath, releaseTypeScope } = OPTIONS) => {
+  const isArray = Array.isArray(releaseTypeScope);
+
+  return runCmd(
     `git add ${join(contextPath, 'package.json')} ${join(contextPath, 'CHANGELOG.md')} && git commit ${join(
       contextPath,
       'package.json'
-    )} ${join(contextPath, 'CHANGELOG.md')} -m "${releaseTypeScope}: ${version}"`,
+    )} ${join(contextPath, 'CHANGELOG.md')} -m "${(isArray && releaseTypeScope?.[0]) || releaseTypeScope}: ${version}"`,
     'Skipping release commit... {0}'
   );
+};
 
 /**
  * Get current package.json version
@@ -57,11 +60,19 @@ const getCurrentVersion = ({ contextPath } = OPTIONS) => {
  * Get last release commit hash
  *
  * @param {object} options
- * @param {string} options.releaseTypeScope
+ * @param {string[]|string} options.releaseTypeScope
  * @returns {string}
  */
-const getReleaseCommit = ({ releaseTypeScope = 'chore(release)' } = OPTIONS) =>
-  runCmd(`git log --grep="${releaseTypeScope}" --pretty=oneline -1`, 'Skipping release commit check... {0}');
+const getReleaseCommit = ({ releaseTypeScope } = OPTIONS) => {
+  const isArray = Array.isArray(releaseTypeScope);
+
+  return runCmd(
+    `git log --grep="${
+      (isArray && releaseTypeScope?.[1]) || (isArray && releaseTypeScope?.[0]) || releaseTypeScope
+    }" --pretty=oneline -1`,
+    'Skipping release commit check... {0}'
+  );
+};
 
 /**
  * Get the repositories remote

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -3,8 +3,8 @@
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
   "cmds.js:20:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
-  "cmds.js:138:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "cmds.js:168:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:149:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:179:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
   "files.js:74:    console.info(\` \${updatedBody}\`)",
   "global.js:64:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
   "index.js:47:    console.info( index.js:61:    console.info(color.NOCOLOR)",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- feat(cli): release-message, expose default

### Notes
- exposes the prefix search string used to provide the range of commits in changelog. now a consumer, in theory, could provide
   - their own formatted release commit prefix
   - a new prefix combined with something from their previous changelog format
   - something unexpected, as always =)
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests provide coverage for new feat
   - confirm tests come back clean and expected
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing