### PR TITLE
fix(parse): allow missing scope

### DIFF
--- a/src/__tests__/__snapshots__/files.test.js.snap
+++ b/src/__tests__/__snapshots__/files.test.js.snap
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 * **build** eslint, jsdoc updates  (#16) (d123453)
+*  missing semicolon  (1f1x345)
 
 "
 `;
@@ -40,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 * **build** eslint, jsdoc updates  (#16) (d123453)
+*  missing semicolon  (1f1x345)
 
 "
 `;
@@ -64,6 +66,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 * **build** eslint, jsdoc updates  (#16) (d123453)
+*  missing semicolon  (1f1x345)
 
 "
 `;
@@ -86,6 +89,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 * **build** eslint, jsdoc updates  (#16) (d123453)
+*  missing semicolon  (1f1x345)
 
 "
 `;

--- a/src/__tests__/__snapshots__/parse.test.js.snap
+++ b/src/__tests__/__snapshots__/parse.test.js.snap
@@ -2,9 +2,10 @@
 
 exports[`Parse should format a changelog commit message: formatChangelogMessages 1`] = `
 {
-  "feat": "* **dolor** issues/20 sit enhancements  (1f12345)",
-  "general": "*  Initial commit  (1f12345)",
-  "refactor": "* **file** lorem updates  ([#8](https://localhost/lorem/ipsum/prmock/8)) ([1f12345](https://localhost/lorem/ipsum/commitsmock/1f12345b597123453031234555b6d25574ccacee))",
+  "feat": "* **dolor** issues/20 sit enhancements  (1f72345)",
+  "fix": "*  missing semicolon  (1f12p45)",
+  "general": "*  Initial commit  (1f12s45)",
+  "refactor": "* **file** lorem updates  ([#8](https://localhost/lorem/ipsum/prmock/8)) ([1f1x345](https://localhost/lorem/ipsum/commitsmock/1f1x345b597123453031234555b6d25574ccacee))",
 }
 `;
 
@@ -57,6 +58,7 @@ exports[`Parse should parse a commit listing using conventional commit types and
     "fix": {
       "commits": [
         "* **build** npm packages  (#18) (6112345)",
+        "*  missing semicolon  (1f1x345)",
         "* **build** eslint, jsdoc updates  (#16) (d123453)",
       ],
       "description": "A bug fix",
@@ -105,6 +107,7 @@ exports[`Parse should parse a commit listing using conventional commit types and
     "fix": {
       "commits": [
         "* **build** npm packages  (#18) (6112345)",
+        "*  missing semicolon  (1f1x345)",
         "* **build** eslint, jsdoc updates  (#16) (d123453)",
       ],
       "description": "A bug fix",
@@ -154,6 +157,7 @@ exports[`Parse should parse a commit listing using conventional commit types and
     "fix": {
       "commits": [
         "* **build** npm packages  (#18) (6112345)",
+        "*  missing semicolon  (1f1x345)",
         "* **build** eslint, jsdoc updates  (#16) (d123453)",
       ],
       "description": "A bug fix",
@@ -210,6 +214,7 @@ exports[`Parse should parse a commit listing using conventional commit types and
     "fix": {
       "commits": [
         "* **build** npm packages  ([#18](https://localhost/lorem/ipsum/dolor/18)) ([6112345](https://localhost/lorem/ipsum/sit/611234511234543c39c1234536dc01234521549c))",
+        "*  missing semicolon  ([1f1x345](https://localhost/lorem/ipsum/sit/1f1x345b597123453031234555b6dl2401ccacee))",
         "* **build** eslint, jsdoc updates  ([#16](https://localhost/lorem/ipsum/dolor/16)) ([d123453](https://localhost/lorem/ipsum/sit/d1234537b5e94a6512345xeb96503312345x18d2))",
       ],
       "description": "A bug fix",
@@ -232,7 +237,7 @@ exports[`Parse should parse a commit listing using conventional commit types and
 {
   "commits": {
     "bump": "minor",
-    "weight": 11.899999999999999,
+    "weight": 12,
   },
   "default": {
     "bump": "patch",
@@ -245,15 +250,23 @@ exports[`Parse should parse a commit message: parseCommitMessages 1`] = `
 {
   "feat": {
     "description": "issues/20 sit enhancements",
-    "hash": "1f12345b597123453031234555b6d25574ccacee",
+    "hash": "1f72345b597123453031234555b6d25574ccacee",
     "prNumber": "",
     "scope": "dolor",
     "type": "feat",
     "typeScope": "feat(dolor)",
   },
+  "fix": {
+    "description": "missing semicolon",
+    "hash": "1f12p45b597123453031234555b6dl2401ccacee",
+    "prNumber": "",
+    "scope": undefined,
+    "type": "fix",
+    "typeScope": "fix",
+  },
   "general": {
     "description": "Initial commit",
-    "hash": "1f12345b597123453031234555b6d25574ccacee",
+    "hash": "1f12s45b597123453031234555b6d25574ccacee",
     "prNumber": "",
     "scope": undefined,
     "type": "general",
@@ -261,11 +274,40 @@ exports[`Parse should parse a commit message: parseCommitMessages 1`] = `
   },
   "refactor": {
     "description": "lorem updates ",
-    "hash": "1f12345b597123453031234555b6d25574ccacee",
+    "hash": "1f1x345b597123453031234555b6d25574ccacee",
     "prNumber": "8",
     "scope": "file",
     "type": "refactor",
     "typeScope": "refactor(file)",
+  },
+}
+`;
+
+exports[`Parse should parse a non-conforming commit message: parseNonConformingCommitMessages 1`] = `
+{
+  "misplacedScope": {
+    "description": "missing fix: semicolon",
+    "hash": "1f12p45b597123453031234555b6dl2401ccacee",
+    "prNumber": "",
+    "scope": undefined,
+    "type": "general",
+    "typeScope": undefined,
+  },
+  "noScopeNoSemicolon": {
+    "description": "refactor lorem updates ",
+    "hash": "1f1x345b597123453031234555b6d25574ccacee",
+    "prNumber": "8",
+    "scope": undefined,
+    "type": "general",
+    "typeScope": undefined,
+  },
+  "noTypeWithScope": {
+    "description": "(dolor): issues/20 sit enhancements",
+    "hash": "1f72345b597123453031234555b6d25574ccacee",
+    "prNumber": "",
+    "scope": undefined,
+    "type": "general",
+    "typeScope": undefined,
   },
 }
 `;

--- a/src/__tests__/files.test.js
+++ b/src/__tests__/files.test.js
@@ -20,6 +20,7 @@ describe('Files', () => {
       1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
       53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
       d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
+      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
       e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
       12345dd312345d421231231312312345dca11235 Initial commit
     `;
@@ -33,6 +34,7 @@ describe('Files', () => {
       LASTg45b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
       53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
       d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
+      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
       e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
       FIRSTdd312345d421231231312312345dca11235 Initial-like commit
     `;

--- a/src/__tests__/parse.test.js
+++ b/src/__tests__/parse.test.js
@@ -38,21 +38,36 @@ describe('Parse', () => {
   });
 
   it('should parse a commit message', () => {
-    const commitMessageRefactor = '1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)';
-    const commitMessageFeature = '1f12345b597123453031234555b6d25574ccacee feat(dolor): issues/20 sit enhancements';
-    const commitMessageNonCC = '1f12345b597123453031234555b6d25574ccacee Initial commit';
+    const commitMessageRefactor = '1f1x345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)';
+    const commitMessageFeature = '1f72345b597123453031234555b6d25574ccacee feat(dolor): issues/20 sit enhancements';
+    const commitMessageNoScope = '1f12p45b597123453031234555b6dl2401ccacee fix: missing semicolon';
+    const commitMessageNonCC = '1f12s45b597123453031234555b6d25574ccacee Initial commit';
 
     expect({
       refactor: parseCommitMessage(commitMessageRefactor),
       feat: parseCommitMessage(commitMessageFeature),
-      general: parseCommitMessage(commitMessageNonCC)
+      general: parseCommitMessage(commitMessageNonCC),
+      fix: parseCommitMessage(commitMessageNoScope)
     }).toMatchSnapshot('parseCommitMessages');
   });
 
+  it('should parse a non-conforming commit message', () => {
+    const commitMessageNoScopeNoSemicolon = '1f1x345b597123453031234555b6d25574ccacee refactor lorem updates (#8)';
+    const commitMessageNoTypeWithScope = '1f72345b597123453031234555b6d25574ccacee (dolor): issues/20 sit enhancements';
+    const commitMessageMisplacedScope = '1f12p45b597123453031234555b6dl2401ccacee missing fix: semicolon';
+
+    expect({
+      noScopeNoSemicolon: parseCommitMessage(commitMessageNoScopeNoSemicolon),
+      noTypeWithScope: parseCommitMessage(commitMessageNoTypeWithScope),
+      misplacedScope: parseCommitMessage(commitMessageMisplacedScope)
+    }).toMatchSnapshot('parseNonConformingCommitMessages');
+  });
+
   it('should format a changelog commit message', () => {
-    const commitMessageRefactor = '1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)';
-    const commitMessageFeature = '1f12345b597123453031234555b6d25574ccacee feat(dolor): issues/20 sit enhancements';
-    const commitMessageNonCC = '1f12345b597123453031234555b6d25574ccacee Initial commit';
+    const commitMessageRefactor = '1f1x345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)';
+    const commitMessageFeature = '1f72345b597123453031234555b6d25574ccacee feat(dolor): issues/20 sit enhancements';
+    const commitMessageNoScope = '1f12p45b597123453031234555b6dl2401ccacee fix: missing semicolon';
+    const commitMessageNonCC = '1f12s45b597123453031234555b6d25574ccacee Initial commit';
 
     expect({
       refactor: formatChangelogMessage(
@@ -66,7 +81,8 @@ describe('Parse', () => {
         }
       ),
       feat: formatChangelogMessage(parseCommitMessage(commitMessageFeature)),
-      general: formatChangelogMessage(parseCommitMessage(commitMessageNonCC))
+      general: formatChangelogMessage(parseCommitMessage(commitMessageNonCC)),
+      fix: formatChangelogMessage(parseCommitMessage(commitMessageNoScope))
     }).toMatchSnapshot('formatChangelogMessages');
   });
 
@@ -75,6 +91,7 @@ describe('Parse', () => {
       1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
       53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
       611234511234543c39c1234536dc01234521549c fix(build): npm packages (#18)
+      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
       fe7d312345xe604d8328d025612345925123457b build(deps): bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19)
       d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
       e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)

--- a/src/parse.js
+++ b/src/parse.js
@@ -67,12 +67,12 @@ const parseCommitMessage = (message, { getCommitType: getAliasCommitType = getCo
     hash,
     typeScope,
     type: commitType?.[type]?.value,
-    scope: scope.split(')')[0],
+    scope: scope.split(')')[0] || undefined,
     description: description,
     prNumber: (partialPr.join('(#').trim() || '').replace(/\D/g, '')
   };
 
-  if (!output.typeScope || !output.type || !output.scope) {
+  if (!output.type || (output.type && !descriptionEtAll?.length)) {
     const [hash, ...descriptionEtAll] = message.trim().split(/\s/);
     const [description, ...partialPr] = descriptionEtAll.join(' ').trim().split(/\(#/);
 


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- fix(parse): allow missing scope

### Notes
- missing scope/subject for the following message format `fix: hello world` (vs `fix(someScope): hello world`) had the unintentional side-effect of not showing in the changelog output. this corrects that issue
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean


## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing