### PR TITLE
feat(cli): detect breaking change syntax

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -29,7 +29,8 @@ Functions for `git`, `package.json` version, and more
     * [~getCurrentVersion(options)](#module_Commands..getCurrentVersion) ⇒ <code>\*</code>
     * [~getReleaseCommit(options)](#module_Commands..getReleaseCommit) ⇒ <code>string</code>
     * [~getRemoteUrls(options)](#module_Commands..getRemoteUrls) ⇒ <code>Object</code>
-    * [~getGit(settings)](#module_Commands..getGit) ⇒ <code>string</code>
+    * [~getGit(settings)](#module_Commands..getGit) ⇒ <code>Array</code>
+        * [~getGitLog(commitHash, searchFilter)](#module_Commands..getGit..getGitLog) ⇒ <code>string</code>
     * [~getOverrideVersion(options)](#module_Commands..getOverrideVersion) ⇒ <code>Object</code>
     * [~getVersion(versionBump, settings)](#module_Commands..getVersion) ⇒ <code>string</code>
 
@@ -149,7 +150,7 @@ Get the repositories remote
 
 <a name="module_Commands..getGit"></a>
 
-### Commands~getGit(settings) ⇒ <code>string</code>
+### Commands~getGit(settings) ⇒ <code>Array</code>
 Return output for a range of commits from a hash
 
 **Kind**: inner method of [<code>Commands</code>](#module_Commands)  
@@ -164,6 +165,35 @@ Return output for a range of commits from a hash
     <td>settings</td><td><code>object</code></td>
     </tr><tr>
     <td>settings.getReleaseCommit</td><td><code>function</code></td>
+    </tr><tr>
+    <td>settings.breakingChangeMessageFilter</td><td><code>Array</code></td>
+    </tr><tr>
+    <td>settings.breakingChangeScopeTypeFilter</td><td><code>Array</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="module_Commands..getGit..getGitLog"></a>
+
+#### getGit~getGitLog(commitHash, searchFilter) ⇒ <code>string</code>
+Build git log command
+
+- Filter a range of commits since the last release if it exists
+- Filter breaking change commits with message body syntax
+- Filter breaking change commits with scope type syntax. And apply an additional check to help filter out
+    commits with message body scope type syntax used unintentionally.
+
+**Kind**: inner method of [<code>getGit</code>](#module_Commands..getGit)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>commitHash</td><td><code>string</code></td>
+    </tr><tr>
+    <td>searchFilter</td><td><code>Array</code></td>
     </tr>  </tbody>
 </table>
 
@@ -216,48 +246,55 @@ Update `changelog` and `package.json`
 
 
 * [Files](#module_Files)
-    * [~updateChangelog(parsedCommits, packageVersion, options, settings)](#module_Files..updateChangelog) ⇒ <code>string</code>
+    * [~updateChangelog(params, options, settings)](#module_Files..updateChangelog) ⇒ <code>string</code>
     * [~updatePackage(versionBump, options)](#module_Files..updatePackage) ⇒ <code>string</code>
 
 <a name="module_Files..updateChangelog"></a>
 
-### Files~updateChangelog(parsedCommits, packageVersion, options, settings) ⇒ <code>string</code>
+### Files~updateChangelog(params, options, settings) ⇒ <code>string</code>
 Update CHANGELOG.md with commit output.
 
 **Kind**: inner method of [<code>Files</code>](#module_Files)  
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Description</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>parsedCommits</td><td><code>object</code></td>
+    <td>params</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>packageVersion</td><td><code>*</code> | <code>string</code></td>
+    <td>params.commits</td><td><code>Object</code></td><td></td>
     </tr><tr>
-    <td>options</td><td><code>object</code></td>
+    <td>params.isBreakingChanges</td><td><code>boolean</code></td><td><p>Apply a &#39;major&#39; weight if true</p>
+</td>
     </tr><tr>
-    <td>options.changelogPath</td><td><code>string</code></td>
+    <td>params.packageVersion</td><td><code>*</code> | <code>string</code></td><td></td>
     </tr><tr>
-    <td>options.date</td><td><code>string</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options.isBasic</td><td><code>boolean</code></td>
+    <td>options.changelogPath</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>options.isDryRun</td><td><code>boolean</code></td>
+    <td>options.date</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>options.releaseDescription</td><td><code>string</code></td>
+    <td>options.isBasic</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>settings</td><td><code>object</code></td>
+    <td>options.isDryRun</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>settings.fallbackPackageVersion</td><td><code>string</code></td>
+    <td>options.releaseDescription</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>settings.getComparisonCommitHashes</td><td><code>function</code></td>
+    <td>settings</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>settings.getRemoteUrls</td><td><code>function</code></td>
+    <td>settings.breakingChangeReleaseDesc</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>settings.headerMd</td><td><code>string</code></td>
+    <td>settings.fallbackPackageVersion</td><td><code>string</code></td><td></td>
+    </tr><tr>
+    <td>settings.getComparisonCommitHashes</td><td><code>function</code></td><td></td>
+    </tr><tr>
+    <td>settings.getRemoteUrls</td><td><code>function</code></td><td></td>
+    </tr><tr>
+    <td>settings.headerMd</td><td><code>string</code></td><td></td>
     </tr>  </tbody>
 </table>
 
@@ -377,10 +414,10 @@ Parse and format commit messages
 * [Parse](#module_Parse)
     * [~getCommitType(options)](#module_Parse..getCommitType) ⇒ <code>Object</code>
     * [~getComparisonCommitHashes(settings)](#module_Parse..getComparisonCommitHashes) ⇒ <code>Object</code>
-    * [~parseCommitMessage(message, settings)](#module_Parse..parseCommitMessage) ⇒ <code>Object</code> \| <code>Object</code>
+    * [~parseCommitMessage(params, settings)](#module_Parse..parseCommitMessage) ⇒ <code>Object</code> \| <code>Object</code>
     * [~formatChangelogMessage(params, options, settings)](#module_Parse..formatChangelogMessage) ⇒ <code>string</code>
     * [~parseCommits(settings)](#module_Parse..parseCommits) ⇒ <code>Object</code>
-    * [~semverBump(parsedCommits, options, settings)](#module_Parse..semverBump) ⇒ <code>Object</code>
+    * [~semverBump(params, options, settings)](#module_Parse..semverBump) ⇒ <code>Object</code>
 
 <a name="module_Parse..getCommitType"></a>
 
@@ -426,7 +463,7 @@ In the current context, get the first and last commits based on the last release
 
 <a name="module_Parse..parseCommitMessage"></a>
 
-### Parse~parseCommitMessage(message, settings) ⇒ <code>Object</code> \| <code>Object</code>
+### Parse~parseCommitMessage(params, settings) ⇒ <code>Object</code> \| <code>Object</code>
 Parse a commit message
 
 **Kind**: inner method of [<code>Parse</code>](#module_Parse)  
@@ -438,7 +475,11 @@ Parse a commit message
   </thead>
   <tbody>
 <tr>
-    <td>message</td><td><code>string</code></td>
+    <td>params</td><td><code>object</code></td>
+    </tr><tr>
+    <td>params.message</td><td><code>string</code></td>
+    </tr><tr>
+    <td>params.isBreaking</td><td><code>boolean</code></td>
     </tr><tr>
     <td>settings</td><td><code>object</code></td>
     </tr><tr>
@@ -469,6 +510,8 @@ Format commit message for CHANGELOG.md
     <td>params.prNumber</td><td><code>string</code> | <code>number</code> | <code>*</code></td>
     </tr><tr>
     <td>params.hash</td><td><code>string</code></td>
+    </tr><tr>
+    <td>params.isBreaking</td><td><code>boolean</code></td>
     </tr><tr>
     <td>options</td><td><code>object</code></td>
     </tr><tr>
@@ -508,27 +551,32 @@ Return an object of commit groupings based on "conventional-commit-types"
 
 <a name="module_Parse..semverBump"></a>
 
-### Parse~semverBump(parsedCommits, options, settings) ⇒ <code>Object</code>
+### Parse~semverBump(params, options, settings) ⇒ <code>Object</code>
 Apply a clear weight to commit types, determine MAJOR, MINOR, PATCH
 
 **Kind**: inner method of [<code>Parse</code>](#module_Parse)  
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Description</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>parsedCommits</td><td><code>Object</code></td>
+    <td>params</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options</td><td><code>object</code></td>
+    <td>params.commits</td><td><code>Object</code></td><td></td>
     </tr><tr>
-    <td>options.isOverrideVersion</td><td><code>boolean</code></td>
+    <td>params.isBreakingChanges</td><td><code>boolean</code></td><td><p>Apply a &#39;major&#39; weight if true</p>
+</td>
     </tr><tr>
-    <td>settings</td><td><code>object</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>settings.getCommitType</td><td><code>function</code></td>
+    <td>options.isOverrideVersion</td><td><code>boolean</code></td><td></td>
+    </tr><tr>
+    <td>settings</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>settings.getCommitType</td><td><code>function</code></td><td></td>
     </tr>  </tbody>
 </table>
 

--- a/src/__tests__/__snapshots__/cmds.test.js.snap
+++ b/src/__tests__/__snapshots__/cmds.test.js.snap
@@ -6,7 +6,12 @@ exports[`Commands should attempt to run commands: commands 1`] = `
     "commitFiles": "<execSync>["git add ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md && git commit ../src/__fixtures__/package.json ../src/__fixtures__/CHANGELOG.md -m \\"chore(release): undefined\\""]</execSync>",
   },
   {
-    "getGit": "<execSync>["git log <execSync>[\\"git..HEAD --pretty=oneline"]</execSync>",
+    "getGit": [
+      {
+        "commit": "<execSync>["git log <execSync>[\\"git..HEAD --pretty=oneline"]</execSync>",
+        "isBreaking": false,
+      },
+    ],
   },
   {
     "getOverrideVersion": {

--- a/src/__tests__/__snapshots__/files.test.js.snap
+++ b/src/__tests__/__snapshots__/files.test.js.snap
@@ -8,16 +8,16 @@ All notable changes to this project will be documented in this file.
 
 
 ### Features
-* **dolor** issues/20 sit enhancements  (#8) (53a1234)
+* **dolor** issues/20 sit enhancements (#8) (53a1234)
 
 ### Code Refactoring
-* **file** lorem updates  (#8) (LASTg45)
+* **file** lorem updates (#8) (LASTg45)
 
 ### Chores
-* **build** npm packages  (#15) (e5c456e)
+* **build** npm packages (#15) (e5c456e)
 
 ### Bug Fixes
-* **build** eslint, jsdoc updates  (#16) (d123453)
+* **build** eslint, jsdoc updates (#16) (d123453)
 *  missing semicolon  (1f1x345)
 
 "
@@ -31,16 +31,16 @@ All notable changes to this project will be documented in this file.
 
 
 ### Features
-* **dolor** issues/20 sit enhancements  (#8) (53a1234)
+* **dolor** issues/20 sit enhancements (#8) (53a1234)
 
 ### Code Refactoring
-* **file** lorem updates  (#8) (LASTg45)
+* **file** lorem updates (#8) (LASTg45)
 
 ### Chores
-* **build** npm packages  (#15) (e5c456e)
+* **build** npm packages (#15) (e5c456e)
 
 ### Bug Fixes
-* **build** eslint, jsdoc updates  (#16) (d123453)
+* **build** eslint, jsdoc updates (#16) (d123453)
 *  missing semicolon  (1f1x345)
 
 "
@@ -56,16 +56,16 @@ All notable changes to this project will be documented in this file.
 - \`sit\` (#5678)
 
 ### Features
-* **dolor** issues/20 sit enhancements  (#8) (53a1234)
+* **dolor** issues/20 sit enhancements (#8) (53a1234)
 
 ### Code Refactoring
-* **file** lorem updates  (#8) (LASTg45)
+* **file** lorem updates (#8) (LASTg45)
 
 ### Chores
-* **build** npm packages  (#15) (e5c456e)
+* **build** npm packages (#15) (e5c456e)
 
 ### Bug Fixes
-* **build** eslint, jsdoc updates  (#16) (d123453)
+* **build** eslint, jsdoc updates (#16) (d123453)
 *  missing semicolon  (1f1x345)
 
 "
@@ -76,19 +76,20 @@ exports[`Files should create, and update a basic CHANGELOG.md: changelog 1`] = `
 All notable changes to this project will be documented in this file.
 
 ## ¯\\_(ツ)_/¯ (2022-10-01)
-
+⚠ BREAKING CHANGES
 
 ### Features
-* **dolor** issues/20 sit enhancements  (#8) (53a1234)
+* ⚠ **lorem** lorem dolor sit (#12) (1f12345)
+* **dolor** issues/20 sit enhancements (#8) (53a1234)
 
 ### Code Refactoring
-* **file** lorem updates  (#8) (1f12345)
+* **file** lorem updates (#8) (1f12345)
 
 ### Chores
-* **build** npm packages  (#15) (e5c456e)
+* **build** npm packages (#15) (e5c456e)
 
 ### Bug Fixes
-* **build** eslint, jsdoc updates  (#16) (d123453)
+* **build** eslint, jsdoc updates (#16) (d123453)
 *  missing semicolon  (1f1x345)
 
 "

--- a/src/__tests__/__snapshots__/parse.test.js.snap
+++ b/src/__tests__/__snapshots__/parse.test.js.snap
@@ -5,7 +5,7 @@ exports[`Parse should format a changelog commit message: formatChangelogMessages
   "feat": "* **dolor** issues/20 sit enhancements  (1f72345)",
   "fix": "*  missing semicolon  (1f12p45)",
   "general": "*  Initial commit  (1f12s45)",
-  "refactor": "* **file** lorem updates  ([#8](https://localhost/lorem/ipsum/prmock/8)) ([1f1x345](https://localhost/lorem/ipsum/commitsmock/1f1x345b597123453031234555b6d25574ccacee))",
+  "refactor": "* **file** lorem updates ([#8](https://localhost/lorem/ipsum/prmock/8)) ([1f1x345](https://localhost/lorem/ipsum/commitsmock/1f1x345b597123453031234555b6d25574ccacee))",
 }
 `;
 
@@ -23,234 +23,246 @@ exports[`Parse should get the first, last commits: first and last, release commi
 }
 `;
 
-exports[`Parse should parse a commit listing using conventional commit types and semver: parsed commits 1`] = `
+exports[`Parse should parse a commit listing using conventional commit types: parsed commits 1`] = `
 {
   "basicCommitsNoMarkdownLinks": {
-    "build": {
-      "commits": [
-        "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1  (#19) (fe7d312)",
-        "* **deps** bump actions/cache from 1 to 2  (#12) (112345c)",
-        "* **deps** bump actions/checkout from 1 to 2  (#11) (512345d)",
-        "* **deps** aggregated checks, updates  (#10) (12345d7)",
-        "* **deps** bump actions/github-script from 5 to 6  (#9) (1412345)",
-      ],
-      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
-      "title": "Builds",
-      "value": "build",
+    "commits": {
+      "build": {
+        "commits": [
+          "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19) (fe7d312)",
+          "* **deps** bump actions/cache from 1 to 2 (#12) (112345c)",
+          "* **deps** bump actions/checkout from 1 to 2 (#11) (512345d)",
+          "* **deps** aggregated checks, updates (#10) (12345d7)",
+          "* **deps** bump actions/github-script from 5 to 6 (#9) (1412345)",
+        ],
+        "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+        "title": "Builds",
+        "value": "build",
+      },
+      "chore": {
+        "commits": [
+          "* **build** npm packages (#15) (e5c456e)",
+          "* **build** npm packages (#15) (6f0f55d)",
+        ],
+        "description": "Other changes that don't modify src or test files",
+        "title": "Chores",
+        "value": "chore",
+      },
+      "feat": {
+        "commits": [
+          "* **dolor** issues/20 sit enhancements (#8) (53a1234)",
+        ],
+        "description": "A new feature",
+        "title": "Features",
+        "value": "feat",
+      },
+      "fix": {
+        "commits": [
+          "* **build** npm packages (#18) (6112345)",
+          "*  missing semicolon  (1f1x345)",
+          "* **build** eslint, jsdoc updates (#16) (d123453)",
+        ],
+        "description": "A bug fix",
+        "title": "Bug Fixes",
+        "value": "fix",
+      },
+      "refactor": {
+        "commits": [
+          "* **file** lorem updates (#8) (1f12345)",
+        ],
+        "description": "A code change that neither fixes a bug nor adds a feature",
+        "title": "Code Refactoring",
+        "value": "refactor",
+      },
     },
-    "chore": {
-      "commits": [
-        "* **build** npm packages  (#15) (e5c456e)",
-        "* **build** npm packages  (#15) (6f0f55d)",
-      ],
-      "description": "Other changes that don't modify src or test files",
-      "title": "Chores",
-      "value": "chore",
-    },
-    "feat": {
-      "commits": [
-        "* **dolor** issues/20 sit enhancements  (#8) (53a1234)",
-      ],
-      "description": "A new feature",
-      "title": "Features",
-      "value": "feat",
-    },
-    "fix": {
-      "commits": [
-        "* **build** npm packages  (#18) (6112345)",
-        "*  missing semicolon  (1f1x345)",
-        "* **build** eslint, jsdoc updates  (#16) (d123453)",
-      ],
-      "description": "A bug fix",
-      "title": "Bug Fixes",
-      "value": "fix",
-    },
-    "refactor": {
-      "commits": [
-        "* **file** lorem updates  (#8) (1f12345)",
-      ],
-      "description": "A code change that neither fixes a bug nor adds a feature",
-      "title": "Code Refactoring",
-      "value": "refactor",
-    },
+    "isBreakingChanges": false,
   },
   "commits": {
-    "build": {
-      "commits": [
-        "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1  (#19) (fe7d312)",
-        "* **deps** bump actions/cache from 1 to 2  (#12) (112345c)",
-        "* **deps** bump actions/checkout from 1 to 2  (#11) (512345d)",
-        "* **deps** aggregated checks, updates  (#10) (12345d7)",
-        "* **deps** bump actions/github-script from 5 to 6  (#9) (1412345)",
-      ],
-      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
-      "title": "Builds",
-      "value": "build",
+    "commits": {
+      "build": {
+        "commits": [
+          "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19) (fe7d312)",
+          "* **deps** bump actions/cache from 1 to 2 (#12) (112345c)",
+          "* **deps** bump actions/checkout from 1 to 2 (#11) (512345d)",
+          "* **deps** aggregated checks, updates (#10) (12345d7)",
+          "* **deps** bump actions/github-script from 5 to 6 (#9) (1412345)",
+        ],
+        "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+        "title": "Builds",
+        "value": "build",
+      },
+      "chore": {
+        "commits": [
+          "* **build** npm packages (#15) (e5c456e)",
+          "* **build** npm packages (#15) (6f0f55d)",
+        ],
+        "description": "Other changes that don't modify src or test files",
+        "title": "Chores",
+        "value": "chore",
+      },
+      "feat": {
+        "commits": [
+          "* **dolor** issues/20 sit enhancements (#8) (53a1234)",
+        ],
+        "description": "A new feature",
+        "title": "Features",
+        "value": "feat",
+      },
+      "fix": {
+        "commits": [
+          "* **build** npm packages (#18) (6112345)",
+          "*  missing semicolon  (1f1x345)",
+          "* **build** eslint, jsdoc updates (#16) (d123453)",
+        ],
+        "description": "A bug fix",
+        "title": "Bug Fixes",
+        "value": "fix",
+      },
+      "refactor": {
+        "commits": [
+          "* **file** lorem updates (#8) (1f12345)",
+        ],
+        "description": "A code change that neither fixes a bug nor adds a feature",
+        "title": "Code Refactoring",
+        "value": "refactor",
+      },
     },
-    "chore": {
-      "commits": [
-        "* **build** npm packages  (#15) (e5c456e)",
-        "* **build** npm packages  (#15) (6f0f55d)",
-      ],
-      "description": "Other changes that don't modify src or test files",
-      "title": "Chores",
-      "value": "chore",
-    },
-    "feat": {
-      "commits": [
-        "* **dolor** issues/20 sit enhancements  (#8) (53a1234)",
-      ],
-      "description": "A new feature",
-      "title": "Features",
-      "value": "feat",
-    },
-    "fix": {
-      "commits": [
-        "* **build** npm packages  (#18) (6112345)",
-        "*  missing semicolon  (1f1x345)",
-        "* **build** eslint, jsdoc updates  (#16) (d123453)",
-      ],
-      "description": "A bug fix",
-      "title": "Bug Fixes",
-      "value": "fix",
-    },
-    "refactor": {
-      "commits": [
-        "* **file** lorem updates  (#8) (1f12345)",
-      ],
-      "description": "A code change that neither fixes a bug nor adds a feature",
-      "title": "Code Refactoring",
-      "value": "refactor",
-    },
-  },
-  "default": {},
-  "generalCommits": {
-    "build": {
-      "commits": [
-        "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1  (#19) (fe7d312)",
-        "* **deps** bump actions/cache from 1 to 2  (#12) (112345c)",
-        "* **deps** bump actions/checkout from 1 to 2  (#11) (512345d)",
-        "* **deps** aggregated checks, updates  (#10) (12345d7)",
-        "* **deps** bump actions/github-script from 5 to 6  (#9) (1412345)",
-      ],
-      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
-      "title": "Builds",
-      "value": "build",
-    },
-    "chore": {
-      "commits": [
-        "* **build** npm packages  (#15) (e5c456e)",
-        "* **build** npm packages  (#15) (6f0f55d)",
-      ],
-      "description": "Other changes that don't modify src or test files",
-      "title": "Chores",
-      "value": "chore",
-    },
-    "feat": {
-      "commits": [
-        "* **dolor** issues/20 sit enhancements  (#8) (53a1234)",
-      ],
-      "description": "A new feature",
-      "title": "Features",
-      "value": "feat",
-    },
-    "fix": {
-      "commits": [
-        "* **build** npm packages  (#18) (6112345)",
-        "*  missing semicolon  (1f1x345)",
-        "* **build** eslint, jsdoc updates  (#16) (d123453)",
-      ],
-      "description": "A bug fix",
-      "title": "Bug Fixes",
-      "value": "fix",
-    },
-    "general": {
-      "commits": [
-        "*  Initial commit  (12345dd)",
-      ],
-      "description": "Commits without category",
-      "title": "General",
-      "value": "general",
-    },
-    "refactor": {
-      "commits": [
-        "* **file** lorem updates  (#8) (1f12345)",
-      ],
-      "description": "A code change that neither fixes a bug nor adds a feature",
-      "title": "Code Refactoring",
-      "value": "refactor",
-    },
-  },
-  "urls": {
-    "build": {
-      "commits": [
-        "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1  ([#19](https://localhost/lorem/ipsum/dolor/19)) ([fe7d312](https://localhost/lorem/ipsum/sit/fe7d312345xe604d8328d025612345925123457b))",
-        "* **deps** bump actions/cache from 1 to 2  ([#12](https://localhost/lorem/ipsum/dolor/12)) ([112345c](https://localhost/lorem/ipsum/sit/112345ca212345c8d2d123450c31234588f12345))",
-        "* **deps** bump actions/checkout from 1 to 2  ([#11](https://localhost/lorem/ipsum/dolor/11)) ([512345d](https://localhost/lorem/ipsum/sit/512345d6712345a1234581234501234516b12345))",
-        "* **deps** aggregated checks, updates  ([#10](https://localhost/lorem/ipsum/dolor/10)) ([12345d7](https://localhost/lorem/ipsum/sit/12345d71e12345d2fc712345dd411234586b850a))",
-        "* **deps** bump actions/github-script from 5 to 6  ([#9](https://localhost/lorem/ipsum/dolor/9)) ([1412345](https://localhost/lorem/ipsum/sit/1412345dd312345d4212345d53e12345dca12345))",
-      ],
-      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
-      "title": "Builds",
-      "value": "build",
-    },
-    "chore": {
-      "commits": [
-        "* **build** npm packages  ([#15](https://localhost/lorem/ipsum/dolor/15)) ([e5c456e](https://localhost/lorem/ipsum/sit/e5c456ea12345vv4610fa4aff7812345ss31b1e2))",
-        "* **build** npm packages  ([#15](https://localhost/lorem/ipsum/dolor/15)) ([6f0f55d](https://localhost/lorem/ipsum/sit/6f0f55d32412345221234512345d2345c3212345))",
-      ],
-      "description": "Other changes that don't modify src or test files",
-      "title": "Chores",
-      "value": "chore",
-    },
-    "feat": {
-      "commits": [
-        "* **dolor** issues/20 sit enhancements  ([#8](https://localhost/lorem/ipsum/dolor/8)) ([53a1234](https://localhost/lorem/ipsum/sit/53a12345479ef91123456e921234548ac4123450))",
-      ],
-      "description": "A new feature",
-      "title": "Features",
-      "value": "feat",
-    },
-    "fix": {
-      "commits": [
-        "* **build** npm packages  ([#18](https://localhost/lorem/ipsum/dolor/18)) ([6112345](https://localhost/lorem/ipsum/sit/611234511234543c39c1234536dc01234521549c))",
-        "*  missing semicolon  ([1f1x345](https://localhost/lorem/ipsum/sit/1f1x345b597123453031234555b6dl2401ccacee))",
-        "* **build** eslint, jsdoc updates  ([#16](https://localhost/lorem/ipsum/dolor/16)) ([d123453](https://localhost/lorem/ipsum/sit/d1234537b5e94a6512345xeb96503312345x18d2))",
-      ],
-      "description": "A bug fix",
-      "title": "Bug Fixes",
-      "value": "fix",
-    },
-    "refactor": {
-      "commits": [
-        "* **file** lorem updates  ([#8](https://localhost/lorem/ipsum/dolor/8)) ([1f12345](https://localhost/lorem/ipsum/sit/1f12345b597123453031234555b6d25574ccacee))",
-      ],
-      "description": "A code change that neither fixes a bug nor adds a feature",
-      "title": "Code Refactoring",
-      "value": "refactor",
-    },
-  },
-}
-`;
-
-exports[`Parse should parse a commit listing using conventional commit types and semver: semver bump 1`] = `
-{
-  "commits": {
-    "bump": "minor",
-    "weight": 12,
+    "isBreakingChanges": false,
   },
   "default": {
-    "bump": "patch",
-    "weight": 0,
+    "commits": {},
+    "isBreakingChanges": false,
+  },
+  "generalCommits": {
+    "commits": {
+      "build": {
+        "commits": [
+          "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19) (fe7d312)",
+          "* **deps** bump actions/cache from 1 to 2 (#12) (112345c)",
+          "* **deps** bump actions/checkout from 1 to 2 (#11) (512345d)",
+          "* **deps** aggregated checks, updates (#10) (12345d7)",
+          "* **deps** bump actions/github-script from 5 to 6 (#9) (1412345)",
+        ],
+        "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+        "title": "Builds",
+        "value": "build",
+      },
+      "chore": {
+        "commits": [
+          "* **build** npm packages (#15) (e5c456e)",
+          "* **build** npm packages (#15) (6f0f55d)",
+        ],
+        "description": "Other changes that don't modify src or test files",
+        "title": "Chores",
+        "value": "chore",
+      },
+      "feat": {
+        "commits": [
+          "* **dolor** issues/20 sit enhancements (#8) (53a1234)",
+        ],
+        "description": "A new feature",
+        "title": "Features",
+        "value": "feat",
+      },
+      "fix": {
+        "commits": [
+          "* **build** npm packages (#18) (6112345)",
+          "*  missing semicolon  (1f1x345)",
+          "* **build** eslint, jsdoc updates (#16) (d123453)",
+        ],
+        "description": "A bug fix",
+        "title": "Bug Fixes",
+        "value": "fix",
+      },
+      "general": {
+        "commits": [
+          "*  Initial commit  (12345dd)",
+        ],
+        "description": "Commits without category",
+        "title": "General",
+        "value": "general",
+      },
+      "refactor": {
+        "commits": [
+          "* **file** lorem updates (#8) (1f12345)",
+        ],
+        "description": "A code change that neither fixes a bug nor adds a feature",
+        "title": "Code Refactoring",
+        "value": "refactor",
+      },
+    },
+    "isBreakingChanges": false,
+  },
+  "urls": {
+    "commits": {
+      "build": {
+        "commits": [
+          "* **deps** bump codecov/codecov-action from 1.1.0 to 1.1.1 ([#19](https://localhost/lorem/ipsum/dolor/19)) ([fe7d312](https://localhost/lorem/ipsum/sit/fe7d312345xe604d8328d025612345925123457b))",
+          "* **deps** bump actions/cache from 1 to 2 ([#12](https://localhost/lorem/ipsum/dolor/12)) ([112345c](https://localhost/lorem/ipsum/sit/112345ca212345c8d2d123450c31234588f12345))",
+          "* **deps** bump actions/checkout from 1 to 2 ([#11](https://localhost/lorem/ipsum/dolor/11)) ([512345d](https://localhost/lorem/ipsum/sit/512345d6712345a1234581234501234516b12345))",
+          "* **deps** aggregated checks, updates ([#10](https://localhost/lorem/ipsum/dolor/10)) ([12345d7](https://localhost/lorem/ipsum/sit/12345d71e12345d2fc712345dd411234586b850a))",
+          "* **deps** bump actions/github-script from 5 to 6 ([#9](https://localhost/lorem/ipsum/dolor/9)) ([1412345](https://localhost/lorem/ipsum/sit/1412345dd312345d4212345d53e12345dca12345))",
+        ],
+        "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+        "title": "Builds",
+        "value": "build",
+      },
+      "chore": {
+        "commits": [
+          "* **build** npm packages ([#15](https://localhost/lorem/ipsum/dolor/15)) ([e5c456e](https://localhost/lorem/ipsum/sit/e5c456ea12345vv4610fa4aff7812345ss31b1e2))",
+          "* **build** npm packages ([#15](https://localhost/lorem/ipsum/dolor/15)) ([6f0f55d](https://localhost/lorem/ipsum/sit/6f0f55d32412345221234512345d2345c3212345))",
+        ],
+        "description": "Other changes that don't modify src or test files",
+        "title": "Chores",
+        "value": "chore",
+      },
+      "feat": {
+        "commits": [
+          "* **dolor** issues/20 sit enhancements ([#8](https://localhost/lorem/ipsum/dolor/8)) ([53a1234](https://localhost/lorem/ipsum/sit/53a12345479ef91123456e921234548ac4123450))",
+        ],
+        "description": "A new feature",
+        "title": "Features",
+        "value": "feat",
+      },
+      "fix": {
+        "commits": [
+          "* **build** npm packages ([#18](https://localhost/lorem/ipsum/dolor/18)) ([6112345](https://localhost/lorem/ipsum/sit/611234511234543c39c1234536dc01234521549c))",
+          "*  missing semicolon  ([1f1x345](https://localhost/lorem/ipsum/sit/1f1x345b597123453031234555b6dl2401ccacee))",
+          "* **build** eslint, jsdoc updates ([#16](https://localhost/lorem/ipsum/dolor/16)) ([d123453](https://localhost/lorem/ipsum/sit/d1234537b5e94a6512345xeb96503312345x18d2))",
+        ],
+        "description": "A bug fix",
+        "title": "Bug Fixes",
+        "value": "fix",
+      },
+      "refactor": {
+        "commits": [
+          "* **file** lorem updates ([#8](https://localhost/lorem/ipsum/dolor/8)) ([1f12345](https://localhost/lorem/ipsum/sit/1f12345b597123453031234555b6d25574ccacee))",
+        ],
+        "description": "A code change that neither fixes a bug nor adds a feature",
+        "title": "Code Refactoring",
+        "value": "refactor",
+      },
+    },
+    "isBreakingChanges": false,
   },
 }
 `;
 
 exports[`Parse should parse a commit message: parseCommitMessages 1`] = `
 {
+  "breaking": {
+    "description": "dolor sit redo",
+    "hash": "1f1x3Ubc81234530312x434555b6d25574ccacee",
+    "isBreaking": true,
+    "prNumber": "8",
+    "scope": undefined,
+    "type": "refactor",
+    "typeScope": "refactor",
+  },
   "feat": {
     "description": "issues/20 sit enhancements",
     "hash": "1f72345b597123453031234555b6d25574ccacee",
+    "isBreaking": false,
     "prNumber": "",
     "scope": "dolor",
     "type": "feat",
@@ -259,6 +271,7 @@ exports[`Parse should parse a commit message: parseCommitMessages 1`] = `
   "fix": {
     "description": "missing semicolon",
     "hash": "1f12p45b597123453031234555b6dl2401ccacee",
+    "isBreaking": false,
     "prNumber": "",
     "scope": undefined,
     "type": "fix",
@@ -267,14 +280,16 @@ exports[`Parse should parse a commit message: parseCommitMessages 1`] = `
   "general": {
     "description": "Initial commit",
     "hash": "1f12s45b597123453031234555b6d25574ccacee",
+    "isBreaking": false,
     "prNumber": "",
     "scope": undefined,
     "type": "general",
     "typeScope": undefined,
   },
   "refactor": {
-    "description": "lorem updates ",
+    "description": "lorem updates",
     "hash": "1f1x345b597123453031234555b6d25574ccacee",
+    "isBreaking": false,
     "prNumber": "8",
     "scope": "file",
     "type": "refactor",
@@ -288,14 +303,16 @@ exports[`Parse should parse a non-conforming commit message: parseNonConformingC
   "misplacedScope": {
     "description": "missing fix: semicolon",
     "hash": "1f12p45b597123453031234555b6dl2401ccacee",
+    "isBreaking": false,
     "prNumber": "",
     "scope": undefined,
     "type": "general",
     "typeScope": undefined,
   },
   "noScopeNoSemicolon": {
-    "description": "refactor lorem updates ",
+    "description": "refactor lorem updates",
     "hash": "1f1x345b597123453031234555b6d25574ccacee",
+    "isBreaking": false,
     "prNumber": "8",
     "scope": undefined,
     "type": "general",
@@ -304,10 +321,28 @@ exports[`Parse should parse a non-conforming commit message: parseNonConformingC
   "noTypeWithScope": {
     "description": "(dolor): issues/20 sit enhancements",
     "hash": "1f72345b597123453031234555b6d25574ccacee",
+    "isBreaking": false,
     "prNumber": "",
     "scope": undefined,
     "type": "general",
     "typeScope": undefined,
+  },
+}
+`;
+
+exports[`Parse should return a semver version: semver bump 1`] = `
+{
+  "breaking": {
+    "bump": "major",
+    "weight": 112,
+  },
+  "commits": {
+    "bump": "minor",
+    "weight": 12,
+  },
+  "default": {
+    "bump": "patch",
+    "weight": 0,
   },
 }
 `;

--- a/src/__tests__/files.test.js
+++ b/src/__tests__/files.test.js
@@ -16,28 +16,29 @@ describe('Files', () => {
   });
 
   it('should create, and update a basic CHANGELOG.md', () => {
-    const commitLog = `
-      1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
-      53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
-      d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
-      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
-      e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
-      12345dd312345d421231231312312345dca11235 Initial commit
-    `;
+    const commitLog = [
+      { commit: '1f12345b597123453031234555b6d25574ccacee feat(lorem)!: lorem dolor sit (#12)', isBreaking: true },
+      { commit: '1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },
+      { commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)' },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: '1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' },
+      { commit: '12345dd312345d421231231312312345dca11235 Initial commit' }
+    ];
 
     const commitObj = parseCommits({ getGit: () => commitLog });
-    expect(updateChangelog(commitObj, undefined)).toMatchSnapshot('changelog');
+    expect(updateChangelog({ ...commitObj }, undefined)).toMatchSnapshot('changelog');
   });
 
   it('should create, and update CHANGELOG.md version with a comparison urls', () => {
-    const commitLog = `
-      LASTg45b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
-      53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
-      d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
-      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
-      e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
-      FIRSTdd312345d421231231312312345dca11235 Initial-like commit
-    `;
+    const commitLog = [
+      { commit: 'LASTg45b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },
+      { commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)' },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: '1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' },
+      { commit: 'FIRSTdd312345d421231231312312345dca11235 Initial-like commit' }
+    ];
 
     const urlObj = {
       compareUrl: 'https://localhost/lorem/ipsum/comparmock/'
@@ -50,19 +51,20 @@ describe('Files', () => {
     });
 
     expect(
-      updateChangelog(commitObj, '1.0.0', undefined, {
+      updateChangelog({ ...commitObj, packageVersion: '1.0.0' }, undefined, {
         getComparisonCommitHashes: () => comparisonObjNoReleaseCommit,
         getRemoteUrls: () => urlObj
       })
     ).toMatchSnapshot('urls and paths, no release commit');
 
+    commitLog.push({ commit: 'REALFIRST2345d421231231312312345dca11235 chore(release): 0.1.0' });
     const comparisonObjReleaseCommit = getComparisonCommitHashes({
-      getGit: () => `${commitLog}\nREALFIRST2345d421231231312312345dca11235 chore(release): 0.1.0`,
+      getGit: () => commitLog,
       getReleaseCommit: () => 'REALFIRST2345d421231231312312345dca11235'
     });
 
     expect(
-      updateChangelog(commitObj, '1.0.0', undefined, {
+      updateChangelog({ ...commitObj, packageVersion: '1.0.0' }, undefined, {
         getComparisonCommitHashes: () => comparisonObjReleaseCommit,
         getRemoteUrls: () => urlObj
       })
@@ -70,8 +72,7 @@ describe('Files', () => {
 
     expect(
       updateChangelog(
-        commitObj,
-        '1.0.0',
+        { ...commitObj, packageVersion: '1.0.0' },
         {
           ...OPTIONS,
           isBasic: true,

--- a/src/__tests__/parse.test.js
+++ b/src/__tests__/parse.test.js
@@ -16,13 +16,13 @@ describe('Parse', () => {
   });
 
   it('should get the first, last commits', () => {
-    const commitLog = `
-      LAST1f12345b597123453031234555bvvvccacee refactor(file): lorem updates (#8)
-      53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
-      d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
-      e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
-      FIRST12345dd312345d42123123131231ca11235 Initial-like commit
-    `;
+    const commitLog = [
+      { commit: 'LAST1f12345b597123453031234555bvvvccacee refactor(file): lorem updates (#8)' },
+      { commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)' },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' },
+      { commit: 'FIRST12345dd312345d42123123131231ca11235 Initial-like commit' }
+    ];
 
     const comparisonObjNoReleaseCommit = getComparisonCommitHashes({
       getGit: () => commitLog,
@@ -30,24 +30,27 @@ describe('Parse', () => {
     });
     expect(comparisonObjNoReleaseCommit).toMatchSnapshot('first and last, no release commit');
 
+    commitLog.push({ commit: 'REALFIRST123452345d42123123131231ca11235 chore(release): 0.1.0' });
     const comparisonObjReleaseCommit = getComparisonCommitHashes({
-      getGit: () => `${commitLog}\nREALFIRST123452345d42123123131231ca11235 chore(release): 0.1.0`,
+      getGit: () => commitLog,
       getReleaseCommit: () => 'REALFIRST123452345d42123123131231ca11235'
     });
     expect(comparisonObjReleaseCommit).toMatchSnapshot('first and last, release commit');
   });
 
   it('should parse a commit message', () => {
+    const commitMessageBreaking = '1f1x3Ubc81234530312x434555b6d25574ccacee refactor!: dolor sit redo (#8)';
     const commitMessageRefactor = '1f1x345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)';
     const commitMessageFeature = '1f72345b597123453031234555b6d25574ccacee feat(dolor): issues/20 sit enhancements';
     const commitMessageNoScope = '1f12p45b597123453031234555b6dl2401ccacee fix: missing semicolon';
     const commitMessageNonCC = '1f12s45b597123453031234555b6d25574ccacee Initial commit';
 
     expect({
-      refactor: parseCommitMessage(commitMessageRefactor),
-      feat: parseCommitMessage(commitMessageFeature),
-      general: parseCommitMessage(commitMessageNonCC),
-      fix: parseCommitMessage(commitMessageNoScope)
+      breaking: parseCommitMessage({ message: commitMessageBreaking, isBreaking: true }),
+      refactor: parseCommitMessage({ message: commitMessageRefactor }),
+      feat: parseCommitMessage({ message: commitMessageFeature }),
+      general: parseCommitMessage({ message: commitMessageNonCC }),
+      fix: parseCommitMessage({ message: commitMessageNoScope })
     }).toMatchSnapshot('parseCommitMessages');
   });
 
@@ -57,9 +60,9 @@ describe('Parse', () => {
     const commitMessageMisplacedScope = '1f12p45b597123453031234555b6dl2401ccacee missing fix: semicolon';
 
     expect({
-      noScopeNoSemicolon: parseCommitMessage(commitMessageNoScopeNoSemicolon),
-      noTypeWithScope: parseCommitMessage(commitMessageNoTypeWithScope),
-      misplacedScope: parseCommitMessage(commitMessageMisplacedScope)
+      noScopeNoSemicolon: parseCommitMessage({ message: commitMessageNoScopeNoSemicolon }),
+      noTypeWithScope: parseCommitMessage({ message: commitMessageNoTypeWithScope }),
+      misplacedScope: parseCommitMessage({ message: commitMessageMisplacedScope })
     }).toMatchSnapshot('parseNonConformingCommitMessages');
   });
 
@@ -71,7 +74,7 @@ describe('Parse', () => {
 
     expect({
       refactor: formatChangelogMessage(
-        parseCommitMessage(commitMessageRefactor),
+        parseCommitMessage({ message: commitMessageRefactor }),
         {},
         {
           getRemoteUrls: () => ({
@@ -80,28 +83,31 @@ describe('Parse', () => {
           })
         }
       ),
-      feat: formatChangelogMessage(parseCommitMessage(commitMessageFeature)),
-      general: formatChangelogMessage(parseCommitMessage(commitMessageNonCC)),
-      fix: formatChangelogMessage(parseCommitMessage(commitMessageNoScope))
+      feat: formatChangelogMessage(parseCommitMessage({ message: commitMessageFeature })),
+      general: formatChangelogMessage(parseCommitMessage({ message: commitMessageNonCC })),
+      fix: formatChangelogMessage(parseCommitMessage({ message: commitMessageNoScope }))
     }).toMatchSnapshot('formatChangelogMessages');
   });
 
-  it('should parse a commit listing using conventional commit types and semver', () => {
-    const commitLog = `
-      1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)
-      53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)
-      611234511234543c39c1234536dc01234521549c fix(build): npm packages (#18)
-      1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon
-      fe7d312345xe604d8328d025612345925123457b build(deps): bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19)
-      d1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)
-      e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)
-      6f0f55d32412345221234512345d2345c3212345 chore(build): npm packages (#15)
-      112345ca212345c8d2d123450c31234588f12345 build(deps): bump actions/cache from 1 to 2 (#12)
-      512345d6712345a1234581234501234516b12345 build(deps): bump actions/checkout from 1 to 2 (#11)
-      12345d71e12345d2fc712345dd411234586b850a build(deps): aggregated checks, updates (#10)
-      1412345dd312345d4212345d53e12345dca12345 build(deps): bump actions/github-script from 5 to 6 (#9)
-      12345dd312345d421231231312312345dca11235 Initial commit
-    `;
+  it('should parse a commit listing using conventional commit types', () => {
+    const commitLog = [
+      { commit: '1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },
+      { commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)' },
+      { commit: '611234511234543c39c1234536dc01234521549c fix(build): npm packages (#18)' },
+      { commit: '1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon' },
+      {
+        commit:
+          'fe7d312345xe604d8328d025612345925123457b build(deps): bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19)'
+      },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' },
+      { commit: '6f0f55d32412345221234512345d2345c3212345 chore(build): npm packages (#15)' },
+      { commit: '112345ca212345c8d2d123450c31234588f12345 build(deps): bump actions/cache from 1 to 2 (#12)' },
+      { commit: '512345d6712345a1234581234501234516b12345 build(deps): bump actions/checkout from 1 to 2 (#11)' },
+      { commit: '12345d71e12345d2fc712345dd411234586b850a build(deps): aggregated checks, updates (#10)' },
+      { commit: '1412345dd312345d4212345d53e12345dca12345 build(deps): bump actions/github-script from 5 to 6 (#9)' },
+      { commit: '12345dd312345d421231231312312345dca11235 Initial commit' }
+    ];
 
     // Basic
     const commitObj = parseCommits({ getGit: () => commitLog });
@@ -140,6 +146,33 @@ describe('Parse', () => {
       basicCommitsNoMarkdownLinks: basicCommitsNoMarkdownLinksObj,
       generalCommits: generalCommitsObj
     }).toMatchSnapshot('parsed commits');
-    expect({ default: semverBump(), commits: semverBump(commitObj) }).toMatchSnapshot('semver bump');
+  });
+
+  it('should return a semver version', () => {
+    const commitLog = [
+      { commit: '1f12345b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },
+      { commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor): issues/20 sit enhancements (#8)' },
+      { commit: '611234511234543c39c1234536dc01234521549c fix(build): npm packages (#18)' },
+      { commit: '1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon' },
+      {
+        commit:
+          'fe7d312345xe604d8328d025612345925123457b build(deps): bump codecov/codecov-action from 1.1.0 to 1.1.1 (#19)'
+      },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' },
+      { commit: '6f0f55d32412345221234512345d2345c3212345 chore(build): npm packages (#15)' },
+      { commit: '112345ca212345c8d2d123450c31234588f12345 build(deps): bump actions/cache from 1 to 2 (#12)' },
+      { commit: '512345d6712345a1234581234501234516b12345 build(deps): bump actions/checkout from 1 to 2 (#11)' },
+      { commit: '12345d71e12345d2fc712345dd411234586b850a build(deps): aggregated checks, updates (#10)' },
+      { commit: '1412345dd312345d4212345d53e12345dca12345 build(deps): bump actions/github-script from 5 to 6 (#9)' },
+      { commit: '12345dd312345d421231231312312345dca11235 Initial commit' }
+    ];
+
+    const commitObj = parseCommits({ getGit: () => commitLog });
+    expect({
+      default: semverBump(),
+      commits: semverBump(commitObj),
+      breaking: semverBump({ ...commitObj, isBreakingChanges: true })
+    }).toMatchSnapshot('semver bump');
   });
 });

--- a/src/files.js
+++ b/src/files.js
@@ -17,8 +17,10 @@ const { getComparisonCommitHashes } = require('./parse');
 /**
  * Update CHANGELOG.md with commit output.
  *
- * @param {object} parsedCommits
- * @param {*|string} packageVersion
+ * @param {object} params
+ * @param {{ feat: { commits: Array }, refactor: { commits: Array }, fix: { commits: Array } }} params.commits
+ * @param {boolean} params.isBreakingChanges Apply a 'major' weight if true
+ * @param {*|string} params.packageVersion
  * @param {object} options
  * @param {string} options.changelogPath
  * @param {string} options.date
@@ -26,6 +28,7 @@ const { getComparisonCommitHashes } = require('./parse');
  * @param {boolean} options.isDryRun
  * @param {string} options.releaseDescription
  * @param {object} settings
+ * @param {string} settings.breakingChangeReleaseDesc
  * @param {string} settings.fallbackPackageVersion
  * @param {Function} settings.getComparisonCommitHashes
  * @param {Function} settings.getRemoteUrls
@@ -33,10 +36,10 @@ const { getComparisonCommitHashes } = require('./parse');
  * @returns {string}
  */
 const updateChangelog = (
-  parsedCommits = {},
-  packageVersion,
+  { commits: parsedCommits = {}, isBreakingChanges = false, packageVersion } = {},
   { date, changelogPath, isBasic = false, isDryRun = false, releaseDescription } = OPTIONS,
   {
+    breakingChangeReleaseDesc = `\u26A0 BREAKING CHANGES`,
     fallbackPackageVersion = '¯\\_(ツ)_/¯',
     getComparisonCommitHashes: getAliasComparisonCommitHashes = getComparisonCommitHashes,
     getRemoteUrls: getAliasRemoteUrls = getRemoteUrls,
@@ -47,7 +50,7 @@ const updateChangelog = (
     timeZone: 'UTC'
   });
   const { compareUrl } = getAliasRemoteUrls();
-  const updatedReleaseDescription = releaseDescription || '';
+  const updatedReleaseDescription = releaseDescription || (isBreakingChanges && breakingChangeReleaseDesc) || '';
   let header = headerMd;
   let version = fallbackPackageVersion;
   let body = '';

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,8 @@ const commitChangelog = (
     process.chdir(contextPath);
   }
 
-  const parsedCommits = parseAliasCommits();
-  const { bump, weight } = semverAliasBump(parsedCommits);
+  const { commits, isBreakingChanges } = parseAliasCommits();
+  const { bump, weight } = semverAliasBump({ commits, isBreakingChanges });
   const { clean: cleanVersion, version } = (overrideVersion && getAliasOverrideVersion()) || getAliasVersion(bump);
 
   if (isDryRun) {
@@ -57,7 +57,7 @@ const commitChangelog = (
     );
   }
 
-  const changelog = updateAliasChangelog(parsedCommits, cleanVersion);
+  const changelog = updateAliasChangelog({ commits, packageVersion: cleanVersion, isBreakingChanges });
   const packageJSON = updateAliasPackage((overrideVersion && cleanVersion) || bump);
 
   if (isCommit && !isDryRun) {
@@ -71,7 +71,7 @@ const commitChangelog = (
   return {
     changelog,
     package: packageJSON,
-    parsedCommits,
+    parsedCommits: commits,
     semverBump: bump,
     semverWeight: weight,
     version,

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -3,9 +3,9 @@
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
   "cmds.js:27:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
-  "cmds.js:156:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "cmds.js:186:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "files.js:82:    console.info(\` \${updatedBody}\`)",
+  "cmds.js:218:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:248:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "files.js:85:    console.info(\` \${updatedBody}\`)",
   "global.js:68:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
   "index.js:54:    console.info( index.js:68:    console.info(color.NOCOLOR)",
 ]


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- feat(cli): detect breaking change syntax

### Notes
- the original intention of keeping changelog-light "light" included the ability to provide your own custom message. the intention being the maintainer could simply fill in the blanks on breaking changes... for us personally this became annoying to use, now the tool reads the accepted syntax for breaking change commit messages (plus a slight variation to account for future language formats), this includes
   - `'BREAKING CHANGE:', 'BREAKING CHANGES:'` within the commit message body
   - and `')!:', '!:'`to account for commit message subject lines
- there is an aspect of "finding commits" that contain the breaking change syntax that could be deduped using a `Set`, however because of the way we're doing a `find` on the git hash this is unnecessary, currently, [`cmds.js line 195`](https://github.com/cdcabrera/changelog-light/pull/91/files#diff-f3c8618267c0000363eeafe677a60fb69c26416d0fda3c481343fa94d538dcf4R195)
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->


## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing