### PR TITLE
docs(readme): switch to dynamic coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Changelog Light
 [![Build Status](https://github.com/cdcabrera/changelog-light/workflows/Build/badge.svg?branch=main)](https://github.com/cdcabrera/changelog-light/actions?query=workflow%3ABuild)
-[![codecov](https://codecov.io/gh/cdcabrera/changelog-light/branch/main/graph/badge.svg)](https://codecov.io/gh/cdcabrera/changelog-light)
+![coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcdcabrera%2Fchangelog-light%2Fmain%2Fpackage.json&query=%24.coverage.pct&suffix=%25&label=coverage&color=9F3FC0)
 [![License](https://img.shields.io/github/license/cdcabrera/changelog-light.svg)](https://github.com/cdcabrera/changelog-light/blob/main/LICENSE)
 
 Generate a changelog with [conventional commit types](https://www.conventionalcommits.org).

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "build:deps": "bash ./scripts/dependencies.sh --doctor -u --doctorInstall \"yarn\" --doctorTest \"yarn test:deps\"",
     "build:docs": "run-s -l test:docs docs:md",
     "docs:md": "node ./scripts/readme.docs.js",
-    "release": "node ./bin/cli.js",
+    "release": "run-s release:test release:coverage release:commit",
+    "release:commit": "node ./bin/cli.js",
+    "release:coverage": "node ./scripts/coverage.build.js",
+    "release:test": "export CI=true; jest --collectCoverage --coverageReporters=\"json-summary\"",
     "start": "./bin/cli.js",
     "test": "run-s -l test:lint test:spell* test:ci",
     "test:ci": "export CI=true; jest --collectCoverage",
@@ -46,6 +49,12 @@
     "test:local": "jest --watch",
     "test:spell-docs": "cspell ./README.md ./CONTRIBUTING.md --config ./cspell.config.json",
     "test:spell": "cspell './src/**/*.js' './tests/**/*.js' --config ./cspell.config.json"
+  },
+  "coverage": {
+    "total": 214,
+    "covered": 202,
+    "skipped": 0,
+    "pct": 94.39
   },
   "jest": {
     "roots": [

--- a/scripts/coverage.build.js
+++ b/scripts/coverage.build.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Add release coverage totals to package.json for dynamic badge display.
+ *
+ * @param {object} options
+ * @param {string} options.coverageJson
+ * @param {string} options.packageJson
+ */
+const addCoverageTotals = ({
+  coverageJson = path.join(process.cwd(), 'coverage/coverage-summary.json'),
+  packageJson = path.join(process.cwd(), 'package.json')
+} = {}) => {
+  try {
+    if (!fs.existsSync(coverageJson) || !fs.existsSync(packageJson)) {
+      return;
+    }
+    const { total } = require(coverageJson);
+    const resultJsonStr = fs.readFileSync(packageJson);
+    const resultJson = { ...JSON.parse(resultJsonStr.toString()) };
+
+    resultJson.coverage = { ...total?.lines };
+    fs.writeFileSync(packageJson, JSON.stringify(resultJson, null, 2) + '\n');
+  } catch (e) {
+    console.error(new Error(`Add coverage totals: ${e.message}`));
+  }
+};
+
+addCoverageTotals();


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- docs(readme): switch to dynamic coverage badge

### Notes
- flips the coverage badge to something more predictable than codcovs badge...
   - currently the codecov badge is borking and we don't really find it enjoyable to figure out what random codecov requirement changed
- uses [shields.io for a dynamic badge built from json](https://shields.io/badges/dynamic-json-badge)
- badge now only indicates line coverage for the existing release 
- any subsequent coverage changes will be updated when the release script is run, coverage is stored in `package.json`

<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
...

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing