### PR TITLE
refactor(cli)!: rename remote to linkUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,20 @@ or Yarn
         --changelog        Changelog output filename and relative path
                                               [string] [default: "./CHANGELOG.md"]
         --commit-path      [CHANGELOG.md] path used for commits. This will be
-                           "joined" with "remote-url". Defaults to the commits
-                           path for GitHub.          [string] [default: "commit/"]
+                           "joined" with "link-url". Defaults to the commits path
+                           for GitHub.               [string] [default: "commit/"]
         --compare-path     [CHANGELOG.md] path used for version comparison. This
-                           will be "joined" with "remote-url". Defaults to the
+                           will be "joined" with "link-url". Defaults to the
                            comparison path for GitHub.
                                                     [string] [default: "compare/"]
+        --link-url         Url override for updating all [CHANGELOG.md] base urls.
+                           This should start with "http". Attempts to use "$ git
+                           remote get-url origin", if it starts with "http"
+                                                                          [string]
         --package          package.json read, output and relative path
                                               [string] [default: "./package.json"]
         --pr-path          [CHANGELOG.md] path used for PRs/MRs. This will be
-                           "joined" with "remote-url". Defaults to the PR path for
+                           "joined" with "link-url". Defaults to the PR path for
                            GitHub.                     [string] [default: "pull/"]
         --release-message  A list of prefix release scope commit messages. First
                            list item is the new commit message prefix, the second
@@ -73,9 +77,6 @@ or Yarn
                                                [array] [default: "chore(release)"]
         --release-desc     Add a description under the release version header
                            copy. Example, "⚠ BREAKING CHANGES"            [string]
-        --remote-url       Git remote get-url for updating [CHANGELOG.md] base
-                           urls. This should start with "http". Defaults to "$ git
-                           remote get-url origin"                         [string]
     -h, --help             Show help                                     [boolean]
     -v, --version          Show version number                           [boolean]
 ```
@@ -144,11 +145,11 @@ To get your release commit setup from a "forked" repository...
 1. Make sure your working branch is synced and updated with the remote branch you want to merge into
 1. Run and confirm the hashes AND LINKS with the remote align in the terminal with...
    ```
-   $ changelog --dry-run --remote-url https://github.com/[the remote url].git
+   $ changelog --dry-run --link-url https://github.com/[the remote url].git
    ```
 1. Run the release script
    ```
-   $ changelog --remote-url https://github.com/[the remote url].git
+   $ changelog --link-url https://github.com/[the remote url].git
    ```
 1. Setup your pull/merge request, there should be a single commit difference... your release commit.
    > If there is more than one commit difference then you incorrectly synced your branch. Confer online, or with your team, for the git commands needed.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,7 +23,7 @@ const {
   'pr-path': prPath,
   'release-message': releaseTypeScope,
   'release-desc': releaseDescription,
-  'remote-url': remoteUrl
+  'link-url': linkUrl
 } = yargs
   .usage('Generate a CHANGELOG.md with conventional commit types.\n\nUsage: changelog [options]')
   .help('help')
@@ -80,13 +80,18 @@ const {
   .option('commit-path', {
     default: 'commit/',
     describe:
-      '[CHANGELOG.md] path used for commits. This will be "joined" with "remote-url". Defaults to the commits path for GitHub.',
+      '[CHANGELOG.md] path used for commits. This will be "joined" with "link-url". Defaults to the commits path for GitHub.',
     type: 'string'
   })
   .option('compare-path', {
     default: 'compare/',
     describe:
-      '[CHANGELOG.md] path used for version comparison. This will be "joined" with "remote-url". Defaults to the comparison path for GitHub.',
+      '[CHANGELOG.md] path used for version comparison. This will be "joined" with "link-url". Defaults to the comparison path for GitHub.',
+    type: 'string'
+  })
+  .option('link-url', {
+    describe:
+      'Url override for updating all [CHANGELOG.md] base urls. This should start with "http". Attempts to use "$ git remote get-url origin", if it starts with "http"',
     type: 'string'
   })
   .option('package', {
@@ -97,7 +102,7 @@ const {
   .option('pr-path', {
     default: 'pull/',
     describe:
-      '[CHANGELOG.md] path used for PRs/MRs. This will be "joined" with "remote-url". Defaults to the PR path for GitHub.',
+      '[CHANGELOG.md] path used for PRs/MRs. This will be "joined" with "link-url". Defaults to the PR path for GitHub.',
     type: 'string'
   })
   .option('release-message', {
@@ -109,11 +114,6 @@ const {
   .option('release-desc', {
     describe: 'Add a description under the release version header copy. Example, "\u26A0 BREAKING CHANGES"',
     type: 'string'
-  })
-  .option('remote-url', {
-    describe:
-      'Git remote get-url for updating [CHANGELOG.md] base urls. This should start with "http". Defaults to "$ git remote get-url origin"',
-    type: 'string'
   }).argv;
 
 /**
@@ -123,7 +123,7 @@ const {
  *     packageFile: string, releaseDescription: string, isAllowNonConventionalCommits: boolean,
  *     releaseBranch: string, prPath: string, isCommit: boolean, overrideVersion: string|*,
  *     changelogPath: Function, commitPath: string, changelogFile: string,
- *     releaseTypeScope: string[]|string, isDryRun: boolean, remoteUrl: string,
+ *     releaseTypeScope: string[]|string, isDryRun: boolean, linkUrl: string,
  *     isBasic: boolean}}
  * @private
  */
@@ -140,6 +140,7 @@ OPTIONS._set = {
   isDryRun,
   isCommit,
   isOverrideVersion: overrideVersion !== undefined,
+  linkUrl,
   overrideVersion,
   packageFile,
   packagePath: function () {
@@ -148,8 +149,7 @@ OPTIONS._set = {
   prPath,
   releaseBranch,
   releaseDescription,
-  releaseTypeScope,
-  remoteUrl
+  releaseTypeScope
 };
 
 /**

--- a/src/README.md
+++ b/src/README.md
@@ -28,7 +28,7 @@ Functions for `git`, `package.json` version, and more
     * [~commitFiles(version, options)](#module_Commands..commitFiles) ⇒ <code>string</code>
     * [~getCurrentVersion(options)](#module_Commands..getCurrentVersion) ⇒ <code>\*</code>
     * [~getReleaseCommit(options)](#module_Commands..getReleaseCommit) ⇒ <code>string</code>
-    * [~getRemoteUrls(options)](#module_Commands..getRemoteUrls) ⇒ <code>Object</code>
+    * [~getLinkUrls(options)](#module_Commands..getLinkUrls) ⇒ <code>Object</code>
     * [~getGit(options, settings)](#module_Commands..getGit) ⇒ <code>Array</code>
         * [~getGitLog(commitHash, searchFilter)](#module_Commands..getGit..getGitLog) ⇒ <code>string</code>
     * [~getOverrideVersion(options)](#module_Commands..getOverrideVersion) ⇒ <code>Object</code>
@@ -124,10 +124,10 @@ Get last release commit hash
     </tr>  </tbody>
 </table>
 
-<a name="module_Commands..getRemoteUrls"></a>
+<a name="module_Commands..getLinkUrls"></a>
 
-### Commands~getRemoteUrls(options) ⇒ <code>Object</code>
-Get the repositories remote
+### Commands~getLinkUrls(options) ⇒ <code>Object</code>
+Get the base url for links, and then set the multiple link formats for markdown.
 
 **Kind**: inner method of [<code>Commands</code>](#module_Commands)  
 <table>
@@ -144,9 +144,9 @@ Get the repositories remote
     </tr><tr>
     <td>options.comparePath</td><td><code>string</code></td>
     </tr><tr>
-    <td>options.prPath</td><td><code>string</code></td>
+    <td>options.linkUrl</td><td><code>string</code></td>
     </tr><tr>
-    <td>options.remoteUrl</td><td><code>string</code></td>
+    <td>options.prPath</td><td><code>string</code></td>
     </tr>  </tbody>
 </table>
 
@@ -298,7 +298,7 @@ Update CHANGELOG.md with commit output.
     </tr><tr>
     <td>settings.getComparisonCommitHashes</td><td><code>function</code></td><td></td>
     </tr><tr>
-    <td>settings.getRemoteUrls</td><td><code>function</code></td><td></td>
+    <td>settings.getLinkUrls</td><td><code>function</code></td><td></td>
     </tr><tr>
     <td>settings.headerMd</td><td><code>string</code></td><td></td>
     </tr>  </tbody>
@@ -525,7 +525,7 @@ Format commit message for CHANGELOG.md
     </tr><tr>
     <td>settings</td><td><code>object</code></td>
     </tr><tr>
-    <td>settings.getRemoteUrls</td><td><code>function</code></td>
+    <td>settings.getLinkUrls</td><td><code>function</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/__tests__/__snapshots__/cmds.test.js.snap
+++ b/src/__tests__/__snapshots__/cmds.test.js.snap
@@ -14,6 +14,14 @@ exports[`Commands should attempt to run commands: commands 1`] = `
     ],
   },
   {
+    "getLinkUrls": {
+      "baseUrl": undefined,
+      "commitUrl": undefined,
+      "compareUrl": undefined,
+      "prUrl": undefined,
+    },
+  },
+  {
     "getOverrideVersion": {
       "clean": "<semverClean>[null]</semverClean>",
       "version": undefined,
@@ -21,14 +29,6 @@ exports[`Commands should attempt to run commands: commands 1`] = `
   },
   {
     "getReleaseCommit": "<execSync>["git log HEAD --grep=\\"chore(release)\\" --pretty=oneline -1"]</execSync>",
-  },
-  {
-    "getRemoteUrls": {
-      "baseUrl": undefined,
-      "commitUrl": undefined,
-      "compareUrl": undefined,
-      "prUrl": undefined,
-    },
   },
   {
     "getVersion": {

--- a/src/__tests__/files.test.js
+++ b/src/__tests__/files.test.js
@@ -53,7 +53,7 @@ describe('Files', () => {
     expect(
       updateChangelog({ ...commitObj, packageVersion: '1.0.0' }, undefined, {
         getComparisonCommitHashes: () => comparisonObjNoReleaseCommit,
-        getRemoteUrls: () => urlObj
+        getLinkUrls: () => urlObj
       })
     ).toMatchSnapshot('urls and paths, no release commit');
 
@@ -66,7 +66,7 @@ describe('Files', () => {
     expect(
       updateChangelog({ ...commitObj, packageVersion: '1.0.0' }, undefined, {
         getComparisonCommitHashes: () => comparisonObjReleaseCommit,
-        getRemoteUrls: () => urlObj
+        getLinkUrls: () => urlObj
       })
     ).toMatchSnapshot('urls and paths, release commit');
 
@@ -80,7 +80,7 @@ describe('Files', () => {
         },
         {
           getComparisonCommitHashes: () => comparisonObjReleaseCommit,
-          getRemoteUrls: () => urlObj
+          getLinkUrls: () => urlObj
         }
       )
     ).toMatchSnapshot('urls and paths, release commit, no markdown links');

--- a/src/__tests__/parse.test.js
+++ b/src/__tests__/parse.test.js
@@ -83,7 +83,7 @@ describe('Parse', () => {
         parseCommitMessage({ message: commitMessageRefactor }),
         {},
         {
-          getRemoteUrls: () => ({
+          getLinkUrls: () => ({
             commitUrl: 'https://localhost/lorem/ipsum/commitsmock/',
             prUrl: 'https://localhost/lorem/ipsum/prmock/'
           })
@@ -140,7 +140,7 @@ describe('Parse', () => {
     const { mockClear: urlPathObjClear } = mockObjectProperty(OPTIONS, {
       commitPath: 'sit',
       prPath: 'dolor',
-      remoteUrl: 'https://localhost/lorem/ipsum'
+      linkUrl: 'https://localhost/lorem/ipsum'
     });
     const urlPathObj = parseCommits({ getGit: () => commitLog });
     urlPathObjClear();
@@ -150,7 +150,7 @@ describe('Parse', () => {
       commitPath: 'sit',
       isBasic: true,
       prPath: 'dolor',
-      remoteUrl: 'https://localhost/lorem/ipsum'
+      linkUrl: 'https://localhost/lorem/ipsum'
     });
     const basicCommitsNoMarkdownLinksObj = parseCommits({ getGit: () => commitLog });
     basicCommitsNoMarkdownLinksObjClear();
@@ -158,7 +158,7 @@ describe('Parse', () => {
     // Allow general commit messages
     const { mockClear: generalCommitsObjClear } = mockObjectProperty(OPTIONS, {
       isAllowNonConventionalCommits: true,
-      remoteUrl: 'https://localhost/lorem/ipsum'
+      linkUrl: 'https://localhost/lorem/ipsum'
     });
     const generalCommitsObj = parseCommits({ getGit: () => commitLog });
     generalCommitsObjClear();

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -83,17 +83,17 @@ const getReleaseCommit = ({ releaseTypeScope, releaseBranch } = OPTIONS) => {
 };
 
 /**
- * Get the repositories remote
+ * Get the base url for links, and then set the multiple link formats for markdown.
  *
  * @param {object} options
  * @param {string} options.commitPath
  * @param {string} options.comparePath
+ * @param {string} options.linkUrl
  * @param {string} options.prPath
- * @param {string} options.remoteUrl
  * @returns {{baseUrl: string, prUrl, commitUrl}}
  */
-const getRemoteUrls = ({ commitPath, comparePath, prPath, remoteUrl } = OPTIONS) => {
-  const setUrl = remoteUrl || runCmd('git remote get-url origin', 'Skipping remote path check... {0}');
+const getLinkUrls = ({ commitPath, comparePath, linkUrl, prPath } = OPTIONS) => {
+  const setUrl = linkUrl || runCmd('git remote get-url origin', 'Skipping remote path check... {0}');
   let updatedUrl;
   let commitUrl;
   let compareUrl;
@@ -101,9 +101,9 @@ const getRemoteUrls = ({ commitPath, comparePath, prPath, remoteUrl } = OPTIONS)
 
   if (/^http/.test(setUrl)) {
     updatedUrl = setUrl.trim().replace(/(\.git)$/, '');
-    const [protocol, remotePath] = updatedUrl.split('://');
+    const [protocol, linkPath] = updatedUrl.split('://');
     const generateUrl = path => {
-      let tempUrl = typeof path === 'string' && `${protocol}://${join(remotePath, path)}`;
+      let tempUrl = typeof path === 'string' && `${protocol}://${join(linkPath, path)}`;
       if (tempUrl && !/\/$/.test(tempUrl)) {
         tempUrl += '/';
       }
@@ -263,9 +263,9 @@ const getVersion = (versionBump, { getCurrentVersion: getAliasCurrentVersion = g
 module.exports = {
   commitFiles,
   getGit,
+  getLinkUrls,
   getOverrideVersion,
   getReleaseCommit,
-  getRemoteUrls,
   getVersion,
   runCmd
 };

--- a/src/files.js
+++ b/src/files.js
@@ -1,7 +1,7 @@
 const { dirname } = require('path');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
 const { OPTIONS } = require('./global');
-const { getRemoteUrls, runCmd } = require('./cmds');
+const { getLinkUrls, runCmd } = require('./cmds');
 const { getComparisonCommitHashes } = require('./parse');
 
 /**
@@ -31,7 +31,7 @@ const { getComparisonCommitHashes } = require('./parse');
  * @param {string} settings.breakingChangeReleaseDesc
  * @param {string} settings.fallbackPackageVersion
  * @param {Function} settings.getComparisonCommitHashes
- * @param {Function} settings.getRemoteUrls
+ * @param {Function} settings.getLinkUrls
  * @param {string} settings.headerMd
  * @returns {string}
  */
@@ -42,14 +42,14 @@ const updateChangelog = (
     breakingChangeReleaseDesc = `\u26A0 BREAKING CHANGES`,
     fallbackPackageVersion = '¯\\_(ツ)_/¯',
     getComparisonCommitHashes: getAliasComparisonCommitHashes = getComparisonCommitHashes,
-    getRemoteUrls: getAliasRemoteUrls = getRemoteUrls,
+    getLinkUrls: getAliasLinkUrls = getLinkUrls,
     headerMd = `# Changelog\nAll notable changes to this project will be documented in this file.`
   } = {}
 ) => {
   const systemTimestamp = ((date && new Date(date)) || new Date()).toLocaleDateString('fr-CA', {
     timeZone: 'UTC'
   });
-  const { compareUrl } = getAliasRemoteUrls();
+  const { compareUrl } = getAliasLinkUrls();
   const updatedReleaseDescription = releaseDescription || (isBreakingChanges && breakingChangeReleaseDesc) || '';
   let header = headerMd;
   let version = fallbackPackageVersion;

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,5 +1,5 @@
 const { generalCommitType, conventionalCommitType, OPTIONS } = require('./global');
-const { getGit, getReleaseCommit, getRemoteUrls } = require('./cmds');
+const { getGit, getReleaseCommit, getLinkUrls } = require('./cmds');
 
 /**
  * Parse and format commit messages
@@ -106,15 +106,15 @@ const parseCommitMessage = (
  * @param {object} options
  * @param {boolean} options.isBasic
  * @param {object} settings
- * @param {Function} settings.getRemoteUrls
+ * @param {Function} settings.getLinkUrls
  * @returns {string}
  */
 const formatChangelogMessage = (
   { scope, description, prNumber, hash, isBreaking } = {},
   { isBasic } = OPTIONS,
-  { getRemoteUrls: getAliasRemoteUrls = getRemoteUrls } = {}
+  { getLinkUrls: getAliasLinkUrls = getLinkUrls } = {}
 ) => {
-  const { commitUrl, prUrl } = getAliasRemoteUrls();
+  const { commitUrl, prUrl } = getAliasLinkUrls();
   let output;
 
   const updatedBreaking = (isBreaking && '\u26A0 ') || '';


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- refactor(cli)!: rename remote to linkUrl

### Notes
- **this is a breaking chang**e... A CLI option is being renamed
- more accurate naming for CLI option `remote-url`... now renamed `link-url`
   - prep for allowing actual "remote" read associated with the new `--branch` option
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
...

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing