### PR TITLE
fix(lock-file): allow adding lock files during release commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ or Yarn
                            commit                        [boolean] [default: true]
     -d, --date             [CHANGELOG.md] release date in the form of a valid date
                            string. Uses system new Date([your date])
-                                    [string] [default: "2024-01-29T07:40:54.615Z"]
+                                    [string] [default: "2024-03-21T13:20:45.593Z"]
     -n, --non-cc           Allow non-conventional commits to apply a semver weight
                            and appear in [CHANGELOG.md] under a general type
                            description.                 [boolean] [default: false]
@@ -65,6 +65,11 @@ or Yarn
                            This should start with "http". Attempts to use "$ git
                            remote get-url origin", if it starts with "http"
                                                                           [string]
+        --lock-file        Lock file read and relative path. Will attempt to
+                           determine "package-lock.json" or "yarn.lock" use and
+                           updates during release. Use if a "lock-like" file
+                           outside of "package" and "yarn" lock is customized or
+                           used.                                          [string]
         --package          package.json read, output and relative path
                                               [string] [default: "./package.json"]
         --pr-path          [CHANGELOG.md] path used for PRs/MRs. This will be

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const { existsSync } = require('fs');
 const { join } = require('path');
 const yargs = require('yargs');
 const packageJson = require('../package');
@@ -17,6 +18,7 @@ const {
   'compare-path': comparePath,
   date,
   'dry-run': isDryRun,
+  'lock-file': lockFile,
   'non-cc': isAllowNonConventionalCommits,
   override: overrideVersion,
   package: packageFile,
@@ -94,6 +96,11 @@ const {
       'Url override for updating all [CHANGELOG.md] base urls. This should start with "http". Attempts to use "$ git remote get-url origin", if it starts with "http"',
     type: 'string'
   })
+  .option('lock-file', {
+    describe:
+      'Lock file read and relative path. Will attempt to determine "package-lock.json" or "yarn.lock" use and updates during release. Use if a "lock-like" file outside of "package" and "yarn" lock is customized or used.',
+    type: 'string'
+  })
   .option('package', {
     default: './package.json',
     describe: 'package.json read, output and relative path',
@@ -141,6 +148,22 @@ OPTIONS._set = {
   isCommit,
   isOverrideVersion: overrideVersion !== undefined,
   linkUrl,
+  lockFile,
+  lockFilePath: function () {
+    if (lockFile) {
+      return join(this.contextPath, lockFile);
+    }
+
+    const foundLockFile = [join(this.contextPath, 'package-lock.json'), join(this.contextPath, 'yarn.lock')].find(
+      fileAndPath => existsSync(fileAndPath)
+    );
+
+    if (foundLockFile) {
+      return foundLockFile;
+    }
+
+    return undefined;
+  },
   overrideVersion,
   packageFile,
   packagePath: function () {

--- a/src/README.md
+++ b/src/README.md
@@ -78,6 +78,8 @@ Optionally commit CHANGELOG.md, package.json
     </tr><tr>
     <td>options.packagePath</td><td><code>string</code></td>
     </tr><tr>
+    <td>options.lockFilePath</td><td><code>string</code></td>
+    </tr><tr>
     <td>options.releaseTypeScope</td><td><code>Array.&lt;string&gt;</code> | <code>string</code></td>
     </tr>  </tbody>
 </table>

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -37,14 +37,16 @@ const runCmd = (cmd, { errorMessage = 'Skipping... {0}' } = {}) => {
  * @param {object} options
  * @param {string} options.changelogPath
  * @param {string} options.packagePath
+ * @param {string} options.lockFilePath
  * @param {string[]|string} options.releaseTypeScope
  * @returns {string}
  */
-const commitFiles = (version, { changelogPath, packagePath, releaseTypeScope } = OPTIONS) => {
+const commitFiles = (version, { changelogPath, packagePath, lockFilePath, releaseTypeScope } = OPTIONS) => {
   const isArray = Array.isArray(releaseTypeScope);
+  const updatedLockFilePath = (lockFilePath && ` ${lockFilePath}`) || '';
 
   return runCmd(
-    `git add ${packagePath} ${changelogPath} && git commit ${packagePath} ${changelogPath} -m "${
+    `git add ${packagePath} ${changelogPath}${updatedLockFilePath} && git commit ${packagePath} ${changelogPath}${updatedLockFilePath} -m "${
       (isArray && releaseTypeScope?.[0]) || releaseTypeScope
     }: ${version}"`,
     'Skipping release commit... {0}'

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -3,8 +3,8 @@
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
   "cmds.js:27:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
-  "cmds.js:224:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "cmds.js:254:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:226:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:256:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
   "files.js:85:    console.info(\` \${updatedBody}\`)",
   "global.js:68:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
   "index.js:54:    console.info( index.js:68:    console.info(color.NOCOLOR)",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- fix(lock-file): allow adding lock files during release commit

### Notes
- finally allows adding in `package-lock.json` or another custom lock-file to the release commit. the way around this issue before was to simply "not commit" the updates
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
...

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing