### PR TITLE
fix(files): display breaking change title with desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or Yarn
                            for range. [write new, search old]
                                                [array] [default: "chore(release)"]
         --release-desc     Add a description under the release version header
-                           copy. Example, "⚠ BREAKING CHANGES"            [string]
+                           copy. Example, "Lorem ipsum dolor sit!"        [string]
     -h, --help             Show help                                     [boolean]
     -v, --version          Show version number                           [boolean]
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -121,7 +121,7 @@ const {
     type: 'array'
   })
   .option('release-desc', {
-    describe: 'Add a description under the release version header copy. Example, "\u26A0 BREAKING CHANGES"',
+    describe: 'Add a description under the release version header copy. Example, "Lorem ipsum dolor sit!"',
     type: 'string'
   }).argv;
 

--- a/src/__tests__/__snapshots__/files.test.js.snap
+++ b/src/__tests__/__snapshots__/files.test.js.snap
@@ -71,6 +71,74 @@ All notable changes to this project will be documented in this file.
 "
 `;
 
+exports[`Files should create, and update CHANGELOG.md with enhanced descriptions: changelog with breaking 1`] = `
+"# Changelog
+All notable changes to this project will be documented in this file.
+
+## 0.1.0 (2022-10-01)
+⚠ BREAKING CHANGES
+
+### Features
+* ⚠ **dolor** issues/20 sit enhancements (#8) (53a1234)
+
+### Code Refactoring
+* **file** lorem updates (#8) (LASTg45)
+
+### Chores
+* **build** npm packages (#15) (e5c456e)
+
+### Bug Fixes
+* **build** eslint, jsdoc updates (#16) (d123453)
+*  missing semicolon  (1f1x345)
+
+"
+`;
+
+exports[`Files should create, and update CHANGELOG.md with enhanced descriptions: changelog with breaking and description 1`] = `
+"# Changelog
+All notable changes to this project will be documented in this file.
+
+## 0.1.0 (2022-10-01)
+⚠ BREAKING CHANGES
+
+Lorem ipsum dolor sit!
+
+### Features
+* ⚠ **dolor** issues/20 sit enhancements (#8) (53a1234)
+
+### Code Refactoring
+* **file** lorem updates (#8) (LASTg45)
+
+### Chores
+* **build** npm packages (#15) (e5c456e)
+
+### Bug Fixes
+* **build** eslint, jsdoc updates (#16) (d123453)
+*  missing semicolon  (1f1x345)
+
+"
+`;
+
+exports[`Files should create, and update CHANGELOG.md with enhanced descriptions: changelog with description 1`] = `
+"# Changelog
+All notable changes to this project will be documented in this file.
+
+## 0.1.0 (2022-10-01)
+Lorem ipsum dolor sit!
+
+### Code Refactoring
+* **file** lorem updates (#8) (LASTg45)
+
+### Chores
+* **build** npm packages (#15) (e5c456e)
+
+### Bug Fixes
+* **build** eslint, jsdoc updates (#16) (d123453)
+*  missing semicolon  (1f1x345)
+
+"
+`;
+
 exports[`Files should create, and update a basic CHANGELOG.md: changelog 1`] = `
 "# Changelog
 All notable changes to this project will be documented in this file.

--- a/src/__tests__/files.test.js
+++ b/src/__tests__/files.test.js
@@ -30,6 +30,54 @@ describe('Files', () => {
     expect(updateChangelog({ ...commitObj }, undefined)).toMatchSnapshot('changelog');
   });
 
+  it('should create, and update CHANGELOG.md with enhanced descriptions', () => {
+    const commitLog = [
+      { commit: 'LASTg45b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },
+      { commit: 'd1234537b5e94a6512345xeb96503312345x18d2 fix(build): eslint, jsdoc updates (#16)' },
+      { commit: '1f1x345b597123453031234555b6dl2401ccacee fix: missing semicolon' },
+      { commit: 'e5c456ea12345vv4610fa4aff7812345ss31b1e2 chore(build): npm packages (#15)' }
+    ];
+
+    const mockUpdateChangelogDeps = (log, description) => {
+      const urlObj = {
+        compareUrl: 'https://localhost/lorem/ipsum/comparmock/'
+      };
+
+      const commitObj = parseCommits({ getGit: () => log });
+      const comparisonObj = getComparisonCommitHashes({
+        getGit: () => log,
+        getReleaseCommit: () => ''
+      });
+
+      return [
+        { ...commitObj, packageVersion: '0.1.0' },
+        {
+          ...OPTIONS,
+          releaseDescription: description
+        },
+        {
+          getComparisonCommitHashes: () => comparisonObj,
+          getLinkUrls: () => urlObj
+        }
+      ];
+    };
+
+    expect(updateChangelog(...mockUpdateChangelogDeps(commitLog, 'Lorem ipsum dolor sit!'))).toMatchSnapshot('changelog with description');
+
+    commitLog.push({
+      commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor)!: issues/20 sit enhancements (#8)',
+      isBreaking: true
+    });
+
+    expect(updateChangelog(...mockUpdateChangelogDeps(commitLog, undefined))).toMatchSnapshot(
+      'changelog with breaking'
+    );
+
+    expect(updateChangelog(...mockUpdateChangelogDeps(commitLog, 'Lorem ipsum dolor sit!'))).toMatchSnapshot(
+      'changelog with breaking and description'
+    );
+  });
+
   it('should create, and update CHANGELOG.md version with a comparison urls', () => {
     const commitLog = [
       { commit: 'LASTg45b597123453031234555b6d25574ccacee refactor(file): lorem updates (#8)' },

--- a/src/__tests__/files.test.js
+++ b/src/__tests__/files.test.js
@@ -62,7 +62,9 @@ describe('Files', () => {
       ];
     };
 
-    expect(updateChangelog(...mockUpdateChangelogDeps(commitLog, 'Lorem ipsum dolor sit!'))).toMatchSnapshot('changelog with description');
+    expect(updateChangelog(...mockUpdateChangelogDeps(commitLog, 'Lorem ipsum dolor sit!'))).toMatchSnapshot(
+      'changelog with description'
+    );
 
     commitLog.push({
       commit: '53a12345479ef91123456e921234548ac4123450 feat(dolor)!: issues/20 sit enhancements (#8)',

--- a/src/files.js
+++ b/src/files.js
@@ -50,7 +50,14 @@ const updateChangelog = (
     timeZone: 'UTC'
   });
   const { compareUrl } = getAliasLinkUrls();
-  const updatedReleaseDescription = releaseDescription || (isBreakingChanges && breakingChangeReleaseDesc) || '';
+  const updatedReleaseDescription = releaseDescription || '';
+  const updatedBreakingChanges = (isBreakingChanges && breakingChangeReleaseDesc) || '';
+  const fullReleaseDescription =
+    (updatedBreakingChanges &&
+      updatedReleaseDescription &&
+      `${updatedBreakingChanges}\n\n${updatedReleaseDescription}`) ||
+    `${updatedBreakingChanges}${updatedReleaseDescription}`;
+
   let header = headerMd;
   let version = fallbackPackageVersion;
   let body = '';
@@ -78,7 +85,7 @@ const updateChangelog = (
     }
   }
 
-  const updatedBody = `## ${version} (${systemTimestamp})\n${updatedReleaseDescription}\n${displayCommits}`;
+  const updatedBody = `## ${version} (${systemTimestamp})\n${fullReleaseDescription}\n${displayCommits}`;
   const output = `${header}\n\n${updatedBody}\n${body}${(body && '\n') || ''}`;
 
   if (isDryRun) {

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -5,7 +5,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "cmds.js:27:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
   "cmds.js:226:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
   "cmds.js:256:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "files.js:85:    console.info(\` \${updatedBody}\`)",
+  "files.js:92:    console.info(\` \${updatedBody}\`)",
   "global.js:68:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
   "index.js:54:    console.info( index.js:68:    console.info(color.NOCOLOR)",
 ]


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- fix(files): changelog breaking change title with desc

### Notes
- Now adds the description to the "BREAKING CHANGES" subtitle display. 

    Before the feature for breaking changes was added in we allowed a description that a user could apply anything they wanted. 

   Since then we've add the ability to display the breaking changes copy automatically for breaking change commit syntax, but we had been doing an `OR` where either their custom description OR the breaking change syntax was displayed. **NOW** instead we do a basic string concatenation and show both. 

   Plus the user still has the option to go in and add the copy `\u26A0 BREAKING CHANGES` in the event it's not triggered by their commit syntax or there's some other piece we don't account for.
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
...

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing