### PR TITLE
build(deps-dev): bump group with 4 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,18 +17,18 @@
         "changelog": "bin/cli.js"
       },
       "devDependencies": {
-        "cspell": "^8.13.1",
+        "cspell": "^8.14.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-jest": "^28.7.0",
-        "eslint-plugin-jsdoc": "^48.11.0",
+        "eslint-plugin-jest": "^28.8.0",
+        "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "jsdoc-to-markdown": "^8.0.3",
-        "npm-check-updates": "^17.0.2",
+        "npm-check-updates": "^17.1.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3"
       },
@@ -611,26 +611,27 @@
       "dev": true
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.13.1.tgz",
-      "integrity": "sha512-ylAwnIdxBMJ9v6BHpFAQFZM+5zbybLtqVQJG7zQePts4e0/Qr2xjYFbC3F+fovZqyXPIx24BR+S6gFJNO1OdAw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.14.2.tgz",
+      "integrity": "sha512-Kv2Utj/RTSxfufGXkkoTZ/3ErCsYWpCijtDFr/FwSsM7mC0PzLpdlcD9xjtgrJO5Kwp7T47iTG21U4Mwddyi8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
         "@cspell/dict-aws": "^4.0.3",
         "@cspell/dict-bash": "^4.1.3",
-        "@cspell/dict-companies": "^3.1.3",
+        "@cspell/dict-companies": "^3.1.4",
         "@cspell/dict-cpp": "^5.1.12",
         "@cspell/dict-cryptocurrencies": "^5.0.0",
         "@cspell/dict-csharp": "^4.0.2",
-        "@cspell/dict-css": "^4.0.12",
+        "@cspell/dict-css": "^4.0.13",
         "@cspell/dict-dart": "^2.0.3",
         "@cspell/dict-django": "^4.1.0",
         "@cspell/dict-docker": "^1.1.7",
         "@cspell/dict-dotnet": "^5.0.2",
         "@cspell/dict-elixir": "^4.0.3",
         "@cspell/dict-en_us": "^4.3.23",
-        "@cspell/dict-en-common-misspellings": "^2.0.3",
+        "@cspell/dict-en-common-misspellings": "^2.0.4",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.4",
         "@cspell/dict-fonts": "^4.0.0",
@@ -656,13 +657,13 @@
         "@cspell/dict-php": "^4.0.8",
         "@cspell/dict-powershell": "^5.0.5",
         "@cspell/dict-public-licenses": "^2.0.7",
-        "@cspell/dict-python": "^4.2.3",
+        "@cspell/dict-python": "^4.2.4",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^5.0.2",
         "@cspell/dict-rust": "^4.0.5",
         "@cspell/dict-scala": "^5.0.3",
-        "@cspell/dict-software-terms": "^4.0.3",
-        "@cspell/dict-sql": "^2.1.3",
+        "@cspell/dict-software-terms": "^4.0.6",
+        "@cspell/dict-sql": "^2.1.5",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
         "@cspell/dict-terraform": "^1.0.0",
@@ -674,31 +675,34 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.13.1.tgz",
-      "integrity": "sha512-vYZTBRkYjpNBifGNbYQsgIXesDEdUa9QAwllDcLZGKbhh5mY/C1ygPnAVpYDYiJNt1WCeIqW286DUyjRjkmHeA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.14.2.tgz",
+      "integrity": "sha512-TZavcnNIZKX1xC/GNj80RgFVKHCT4pHT0qm9jCsQFH2QJfyCrUlkEvotKGSQ04lAyCwWg6Enq95qhouF8YbKUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.13.1"
+        "@cspell/cspell-types": "8.14.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.13.1.tgz",
-      "integrity": "sha512-acLWTQv3yWfeWXMds/cfQKZapslOrLHVL4VDp4rFyL/EnfgaCr7Ew9hQ7zAIARY3r/n0dByqWbOt2HKthdhx/g==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.14.2.tgz",
+      "integrity": "sha512-aWMoXZAXEre0/M9AYWOW33YyOJZ06i4vvsEpWBDWpHpWQEmsR/7cMMgld8Pp3wlEjIUclUAKTYmrZ61PFWU/og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.13.1.tgz",
-      "integrity": "sha512-EGdb7KLYCklV3sLxf/895b7s6sExh8DCHZFpDos2hjKwMt+F4ynsu1+ceybQtqoUF/MsyLoJXrrmPvV2uGVmUQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.14.2.tgz",
+      "integrity": "sha512-pSyBsAvslaN0dx0pHdvECJEuFDDBJGAD6G8U4BVbIyj2OPk0Ox0HrZIj6csYxxoJERAgNO/q7yCPwa4j9NNFXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "global-directory": "^4.0.1"
       },
@@ -707,19 +711,21 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.13.1.tgz",
-      "integrity": "sha512-oLFJfxuB1rwGXn3eD5qSF9nf0lHu6YjO0JcrjWhAZQ0r3AsO97gsX50wwCFCw6szVU3rd1cTUktW0KYEZUY6dA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.14.2.tgz",
+      "integrity": "sha512-WUF7xf3YgXYIqjmBwLcVugYIrYL4WfXchgSo9rmbbnOcAArzsK+HKfzb4AniZAJ1unxcIQ0JnVlRmnCAKPjjLg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.13.1.tgz",
-      "integrity": "sha512-9dJdmyXLXJVesCJa/DWgwKsEC9p2RRFc6KORcLhNvtm1tE9TvCXiu5jV47sOmYXd6Hwan8IurBXXTz82CLVjPQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.14.2.tgz",
+      "integrity": "sha512-MRY8MjBNOKGMDSkxAKueYAgVL43miO+lDcLCBBP+7cNXqHiUFMIZteONcGp3kJT0dWS04dN6lKAXvaNF0aWcng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -728,253 +734,295 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.2.tgz",
       "integrity": "sha512-0kENOWQeHjUlfyId/aCM/mKXtkEgV0Zu2RhUXCBr4hHo9F9vph+Uu8Ww2b0i5a4ZixoIkudGA+eJvyxrG1jUpA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.3.tgz",
-      "integrity": "sha512-0C0RQ4EM29fH0tIYv+EgDQEum0QI6OrmjENC9u98pB8UcnYxGG/SqinuPxo+TgcEuInj0Q73MsBpJ1l5xUnrsw==",
-      "dev": true
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.4.tgz",
+      "integrity": "sha512-6AWI/Kkf+RcX/J81VX8+GKLeTgHWEr/OMhGk3dHQzWK66RaqDJCGDqi7494ghZKcBB7dGa3U5jcKw2FZHL/u3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-bash": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.3.tgz",
-      "integrity": "sha512-tOdI3QVJDbQSwPjUkOiQFhYcu2eedmX/PtEpVWg0aFps/r6AyjUQINtTgpqMYnYuq8O1QUIQqnpx21aovcgZCw==",
-      "dev": true
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.4.tgz",
+      "integrity": "sha512-W/AHoQcJYn3Vn/tUiXX2+6D/bhfzdDshwcbQWv9TdiNlXP9P6UJjDKWbxyA5ogJCsR2D0X9Kx11oV8E58siGKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-companies": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.4.tgz",
       "integrity": "sha512-y9e0amzEK36EiiKx3VAA+SHQJPpf2Qv5cCt5eTUSggpTkiFkCh6gRKQ97rVlrKh5GJrqinDwYIJtTsxuh2vy2Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.12.tgz",
-      "integrity": "sha512-6lXLOFIa+k/qBcu0bjaE/Kc6v3sh9VhsDOXD1Dalm3zgd0QIMjp5XBmkpSdCAK3pWCPV0Se7ysVLDfCea1BuXg==",
-      "dev": true
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.16.tgz",
+      "integrity": "sha512-32fU5RkuOM55IRcxjByiSoKbjr+C4danDfYjHaQNRWdvjzJzci3fLDGA2wTXiclkgDODxGiV8LCTUwCz+3TNWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.0.tgz",
       "integrity": "sha512-Z4ARIw5+bvmShL+4ZrhDzGhnc9znaAGHOEMaB/GURdS/jdoreEDY34wdN0NtdLHDO5KO7GduZnZyqGdRoiSmYA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-csharp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.2.tgz",
       "integrity": "sha512-1JMofhLK+4p4KairF75D3A924m5ERMgd1GvzhwK2geuYgd2ZKuGW72gvXpIV7aGf52E3Uu1kDXxxGAiZ5uVG7g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.12.tgz",
-      "integrity": "sha512-vGBgPM92MkHQF5/2jsWcnaahOZ+C6OE/fPvd5ScBP72oFY9tn5GLuomcyO0z8vWCr2e0nUSX1OGimPtcQAlvSw==",
-      "dev": true
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.13.tgz",
+      "integrity": "sha512-WfOQkqlAJTo8eIQeztaH0N0P+iF5hsJVKFuhy4jmARPISy8Efcv8QXk2/IVbmjJH0/ZV7dKRdnY5JFVXuVz37g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.0.3.tgz",
       "integrity": "sha512-cLkwo1KT5CJY5N5RJVHks2genFkNCl/WLfj+0fFjqNR+tk3tBI1LY7ldr9piCtSFSm4x9pO1x6IV3kRUY1lLiw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-data-science": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.1.tgz",
       "integrity": "sha512-xeutkzK0eBe+LFXOFU2kJeAYO6IuFUc1g7iRLr7HeCmlC4rsdGclwGHh61KmttL3+YHQytYStxaRBdGAXWC8Lw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-django": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.0.tgz",
       "integrity": "sha512-bKJ4gPyrf+1c78Z0Oc4trEB9MuhcB+Yg+uTTWsvhY6O2ncFYbB/LbEZfqhfmmuK/XJJixXfI1laF2zicyf+l0w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-docker": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.7.tgz",
       "integrity": "sha512-XlXHAr822euV36GGsl2J1CkBIVg3fZ6879ZOg5dxTIssuhUOCiV2BuzKZmt6aIFmcdPmR14+9i9Xq+3zuxeX0A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.2.tgz",
-      "integrity": "sha512-UD/pO2A2zia/YZJ8Kck/F6YyDSpCMq0YvItpd4YbtDVzPREfTZ48FjZsbYi4Jhzwfvc6o8R56JusAE58P+4sNQ==",
-      "dev": true
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.5.tgz",
+      "integrity": "sha512-gjg0L97ee146wX47dnA698cHm85e7EOpf9mVrJD8DmEaqoo/k1oPy2g7c7LgKxK9XnqwoXxhLNnngPrwXOoEtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-elixir": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.3.tgz",
       "integrity": "sha512-g+uKLWvOp9IEZvrIvBPTr/oaO6619uH/wyqypqvwpmnmpjcfi8+/hqZH8YNKt15oviK8k4CkINIqNhyndG9d9Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
       "version": "4.3.23",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.23.tgz",
       "integrity": "sha512-l0SoEQBsi3zDSl3OuL4/apBkxjuj4hLIg/oy6+gZ7LWh03rKdF6VNtSZNXWAmMY+pmb1cGA3ouleTiJIglbsIg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.4.tgz",
       "integrity": "sha512-lvOiRjV/FG4pAGZL3PN2GCVHSTCE92cwhfLGGkOsQtxSmef6WCHfHwp9auafkBlX0yFQSKDfq6/TlpQbjbJBtQ==",
-      "dev": true
+      "dev": true,
+      "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
       "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.4.tgz",
       "integrity": "sha512-IBi8eIVdykoGgIv5wQhOURi5lmCNJq0we6DvqKoPQJHthXbgsuO1qrHSiUVydMiQl/XvcnUWTMeAlVUlUClnVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fonts": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.0.tgz",
       "integrity": "sha512-t9V4GeN/m517UZn63kZPUYP3OQg5f0OBLSd3Md5CU3eH1IFogSvTzHHnz4Wqqbv8NNRiBZ3HfdY/pqREZ6br3Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fsharp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.1.tgz",
       "integrity": "sha512-23xyPcD+j+NnqOjRHgW3IU7Li912SX9wmeefcY0QxukbAxJ/vAN4rBpjSwwYZeQPAn3fxdfdNZs03fg+UM+4yQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.0.tgz",
       "integrity": "sha512-sIGQwU6G3rLTo+nx0GKyirR5dQSFeTIzFTOrURw51ISf+jKG9a3OmvsVtc2OANfvEAOLOC9Wfd8WYhmsO8KRDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-gaming-terms": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.5.tgz",
       "integrity": "sha512-C3riccZDD3d9caJQQs1+MPfrUrQ+0KHdlj9iUR1QD92FgTOF6UxoBpvHUUZ9YSezslcmpFQK4xQQ5FUGS7uWfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-git": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.0.tgz",
       "integrity": "sha512-simGS/lIiXbEaqJu9E2VPoYW1OTC2xrwPPXNXFMa2uo/50av56qOuaxDrZ5eH1LidFXwoc8HROCHYeKoNrDLSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.9.tgz",
-      "integrity": "sha512-etDt2WQauyEQDA+qPS5QtkYTb2I9l5IfQftAllVoB1aOrT6bxxpHvMEpJ0Hsn/vezxrCqa/BmtUbRxllIxIuSg==",
-      "dev": true
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.12.tgz",
+      "integrity": "sha512-LEPeoqd+4O+vceHF73S7D7+LYfrAjOvp4Dqzh4MT30ruzlQ77yHRSuYOJtrFN1GK5ntAt/ILSVOKg9sgsz1Llg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-google": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.1.tgz",
       "integrity": "sha512-dQr4M3n95uOhtloNSgB9tYYGXGGEGEykkFyRtfcp5pFuEecYUa0BSgtlGKx9RXVtJtKgR+yFT/a5uQSlt8WjqQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-haskell": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.1.tgz",
       "integrity": "sha512-uRrl65mGrOmwT7NxspB4xKXFUenNC7IikmpRZW8Uzqbqcu7ZRCUfstuVH7T1rmjRgRkjcIjE4PC11luDou4wEQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.5.tgz",
       "integrity": "sha512-p0brEnRybzSSWi8sGbuVEf7jSTDmXPx7XhQUb5bgG6b54uj+Z0Qf0V2n8b/LWwIPJNd1GygaO9l8k3HTCy1h4w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.0.tgz",
       "integrity": "sha512-HGRu+48ErJjoweR5IbcixxETRewrBb0uxQBd6xFGcxbEYCX8CnQFTAmKI5xNaIt2PKaZiJH3ijodGSqbKdsxhw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.7.tgz",
       "integrity": "sha512-ejQ9iJXYIq7R09BScU2y5OUGrSqwcD+J5mHFOKbduuQ5s/Eh/duz45KOzykeMLI6KHPVxhBKpUPBWIsfewECpQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-julia": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.1.tgz",
       "integrity": "sha512-4JsCLCRhhLMLiaHpmR7zHFjj1qOauzDI5ZzCNQS31TUMfsOo26jAKDfo0jljFAKgw5M2fEG7sKr8IlPpQAYrmQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-k8s": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.6.tgz",
       "integrity": "sha512-srhVDtwrd799uxMpsPOQqeDJY+gEocgZpoK06EFrb4GRYGhv7lXo9Fb+xQMyQytzOW9dw4DNOEck++nacDuymg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-latex": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.0.tgz",
       "integrity": "sha512-LPY4y6D5oI7D3d+5JMJHK/wxYTQa2lJMSNxps2JtuF8hbAnBQb3igoWEjEbIbRRH1XBM0X8dQqemnjQNCiAtxQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lorem-ipsum": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.0.tgz",
       "integrity": "sha512-1l3yjfNvMzZPibW8A7mQU4kTozwVZVw0AvFEdy+NcqtbxH+TvbSkNMqROOFWrkD2PjnKG0+Ea0tHI2Pi6Gchnw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lua": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.3.tgz",
       "integrity": "sha512-lDHKjsrrbqPaea13+G9s0rtXjMO06gPXPYRjRYawbNmo4E/e3XFfVzeci3OQDQNDmf2cPOwt9Ef5lu2lDmwfJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-makefile": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.0.tgz",
       "integrity": "sha512-3W9tHPcSbJa6s0bcqWo6VisEDTSN5zOtDbnPabF7rbyjRpNo0uHXHRJQF8gAbFzoTzBBhgkTmrfSiuyQm7vBUQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-monkeyc": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.6.tgz",
       "integrity": "sha512-oO8ZDu/FtZ55aq9Mb67HtaCnsLn59xvhO/t2mLLTHAp667hJFxpp7bCtr2zOrR1NELzFXmKln/2lw/PvxMSvrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.1.tgz",
       "integrity": "sha512-lax/jGz9h3Dv83v8LHa5G0bf6wm8YVRMzbjJPG/9rp7cAGPtdrga+XANFq+B7bY5+jiSA3zvj10LUFCFjnnCCg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.18.tgz",
-      "integrity": "sha512-weMTyxWpzz19q4wv9n183BtFvdD5fCjtze+bFKpl+4rO/YlPhHL2cXLAeexJz/VDSBecwX4ybTZYoknd1h2J4w==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.1.tgz",
+      "integrity": "sha512-yMAttAXvxtfjg1Oy7Jyq1wqjL3sz41ZP6m2HtvorDZyABk+4hKh8knK1sSZCTcuHpVoWr7yGRGJyAj3anEOxuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.8.tgz",
-      "integrity": "sha512-TBw3won4MCBQ2wdu7kvgOCR3dY2Tb+LJHgDUpuquy3WnzGiSDJ4AVelrZdE1xu7mjFJUr4q48aB21YT5uQqPZA==",
-      "dev": true
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.10.tgz",
+      "integrity": "sha512-NfTZdp6kcZDF1PvgQ6cY0zE4FUO5rSwNmBH/iwCBuaLfJAFQ97rgjxo+D2bic4CFwNjyHutnHPtjJBRANO5XQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-powershell": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.5.tgz",
-      "integrity": "sha512-3JVyvMoDJesAATYGOxcUWPbQPUvpZmkinV3m8HL1w1RrjeMVXXuK7U1jhopSneBtLhkU+9HKFwgh9l9xL9mY2Q==",
-      "dev": true
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.6.tgz",
+      "integrity": "sha512-BSi9tmnT7jgNsH5SaHSg70aw+4YwTjkkZBfhHtin0r6AMV2RaiLzsBPvzZGXOcm0yTvl975HYoKMqflXIlk2RA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.7.tgz",
-      "integrity": "sha512-KlBXuGcN3LE7tQi/GEqKiDewWGGuopiAD0zRK1QilOx5Co8XAvs044gk4MNIQftc8r0nHeUI+irJKLGcR36DIQ==",
-      "dev": true
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.8.tgz",
+      "integrity": "sha512-Sup+tFS7cDV0fgpoKtUqEZ6+fA/H+XUgBiqQ/Fbs6vUE3WCjJHOIVsP+udHuyMH7iBfJ4UFYOYeORcY4EaKdMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.3.tgz",
-      "integrity": "sha512-C1CPX9wwEGgcHv/p7KfjuIOp1G6KNyx5gWYweAd6/KPv+ZpeM1v572zFUTmpO8WDuAfKFf00nqYL8/GmCENWBw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.6.tgz",
+      "integrity": "sha512-Hkz399qDGEbfXi9GYa2hDl7GahglI86JmS2F1KP8sfjLXofUgtnknyC5NWc86nzHcP38pZiPqPbTigyDYw5y8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspell/dict-data-science": "^2.0.1"
       }
@@ -983,73 +1031,85 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.1.tgz",
       "integrity": "sha512-KCmKaeYMLm2Ip79mlYPc8p+B2uzwBp4KMkzeLd5E6jUlCL93Y5Nvq68wV5fRLDRTf7N1LvofkVFWfDcednFOgA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.2.tgz",
-      "integrity": "sha512-cIh8KTjpldzFzKGgrqUX4bFyav5lC52hXDKo4LbRuMVncs3zg4hcSf4HtURY+f2AfEZzN6ZKzXafQpThq3dl2g==",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.3.tgz",
+      "integrity": "sha512-V1xzv9hN6u8r6SM4CkYdsxs4ov8gjXXo0Twfx5kWhLXbEVxTXDMt7ohLTqpy2XlF5mutixZdbHMeFiAww8v+Ug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-rust": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.5.tgz",
       "integrity": "sha512-DIvlPRDemjKQy8rCqftAgGNZxY5Bg+Ps7qAIJjxkSjmMETyDgl0KTVuaJPt7EK4jJt6uCZ4ILy96npsHDPwoXA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-scala": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.3.tgz",
       "integrity": "sha512-4yGb4AInT99rqprxVNT9TYb1YSpq58Owzq7zi3ZS5T0u899Y4VsxsBiOgHnQ/4W+ygi+sp+oqef8w8nABR2lkg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.0.4.tgz",
-      "integrity": "sha512-AHr3Wxa4pxbpKgxhyQseBmoJhdyeraeRGdQn0e8YD5pz4J6Mu47MLzKysasDKWK/yzmHQfwAsb2zm2k+ItMEUw==",
-      "dev": true
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.2.tgz",
+      "integrity": "sha512-+l9E1HaIGHYBm2zooYJa6f+ybw+pUOPM6Md6sH8eoi+Lhyd5Pi0e7HWAYKfgSMz+EK8ObkqKjblu6vuuMllQnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-sql": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.4.tgz",
-      "integrity": "sha512-wsrNK6UBQ92IzQ4SqQqgM04BEYzqVsk3qZH3ZgascaqDtUgK6GI+z3Czi0rQ+9Qe2zKiklGnGMC8sJwYdlIw7g==",
-      "dev": true
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.5.tgz",
+      "integrity": "sha512-FmxanytHXss7GAWAXmgaxl3icTCW7YxlimyOSPNfm+njqeUDjw3kEv4mFNDDObBJv8Ec5AWCbUDkWIpkE3IpKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-svelte": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.2.tgz",
       "integrity": "sha512-rPJmnn/GsDs0btNvrRBciOhngKV98yZ9SHmg8qI6HLS8hZKvcXc0LMsf9LLuMK1TmS2+WQFAan6qeqg6bBxL2Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-swift": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.1.tgz",
       "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.0.tgz",
-      "integrity": "sha512-Ak+vy4HP/bOgzf06BAMC30+ZvL9mzv21xLM2XtfnBLTDJGdxlk/nK0U6QT8VfFLqJ0ZZSpyOxGsUebWDCTr/zQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.1.tgz",
+      "integrity": "sha512-29lmUUnZgPh+ieZ5hunick8hzNIpNRtiJh9vAusNskPCrig3RTW6u7F+GG1a8uyslbzSw+Irjf40PTOan1OJJA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-typescript": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.6.tgz",
       "integrity": "sha512-1beC6O4P/j23VuxX+i0+F7XqPVc3hhiAzGJHEKqnWf5cWAXQtg0xz3xQJ5MvYx2a7iLaSa+lu7+05vG9UHyu9Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.0.tgz",
       "integrity": "sha512-niiEMPWPV9IeRBRzZ0TBZmNnkK3olkOPYxC1Ny2AX4TGlYRajcW0WUtoSHmvvjZNfWLSg2L6ruiBeuPSbjnG6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.13.1.tgz",
-      "integrity": "sha512-jMqJHWmQy+in99JMSFlaGV9P033gCx7DCZvGO/ZSeZ2EatrUTanJk3oTG1TZknZydb0nnxr1mgTWXN7PCAAXDg==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.14.2.tgz",
+      "integrity": "sha512-5MbqtIligU7yPwHWU/5yFCgMvur4i1bRAF1Cy8y2dDtHsa204S/w/SaXs+51EFLp2eNbCiBisCBrwJFT7R1RxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
       },
@@ -1057,33 +1117,46 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@cspell/strong-weak-map": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.13.1.tgz",
-      "integrity": "sha512-ga1ibI9ZLJWNszfP7e6qQ8gnoQOP9rE/clALMAim9ssO6cmMhEEm+i1ROH4nsDfThd6sVlUJ0IOtx5dEqPmWxw==",
+    "node_modules/@cspell/filetypes": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.14.2.tgz",
+      "integrity": "sha512-ZevArA0mWeVTTqHicxCPZIAeCibpY3NwWK/x6d1Lgu7RPk/daoGAM546Q2SLChFu+r10tIH7pRG212A6Q9ihPA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.14.2.tgz",
+      "integrity": "sha512-7sRzJc392CQYNNrtdPEfOHJdRqsqf6nASCtbS5A9hL2UrdWQ4uN7r/D+Y1HpuizwY9eOkZvarcFfsYt5wE0Pug==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.13.1.tgz",
-      "integrity": "sha512-cCyojz5ovgGCexhez2urle4Q1UOEsp96lvl4pDmWNDHa/6n8dqiIn60SVzQIsAHzJ4yEV077RSaIrTlq/T+oSQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.14.2.tgz",
+      "integrity": "sha512-YmWW+B/2XQcCynLpiAQF77Bitm5Cynw3/BICZkbdveKjJkUzEmXB+U2qWuwXOyU8xUYuwkP63YM8McnI567rUA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
-      "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.48.0.tgz",
+      "integrity": "sha512-G6QUWIcC+KvSwXNsJyDTHvqUdNoAVJPPgkc3+Uk4WBKqZvoXhlvazOgm9aL0HwihJLQf0l+tOE2UFzXBqCqgDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "comment-parser": "1.4.1",
         "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~4.0.0"
+        "jsdoc-type-pratt-parser": "~4.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -2465,7 +2538,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2969,6 +3043,7 @@
       "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
       "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^2.0.0",
         "resolve-from": "^5.0.0"
@@ -3200,10 +3275,11 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.4.tgz",
-      "integrity": "sha512-E5AjpSW+O+N5T2GsOQMHLLsJvrYw6G/AFt9GvU6NguEAfzKShh7hRiLtVo6S9KbRpFMGqE5ojo0/hE+sdteWvQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -3220,6 +3296,7 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
       "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -3272,7 +3349,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3359,24 +3437,25 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.13.1.tgz",
-      "integrity": "sha512-Bqppilpwx9xt3jZPaYcqe1JPteNmfKhx9pw9YglZEePDUzdiJQNVIfs31589GAnXjgdqqctR8N87ffLcaBNPXw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.14.2.tgz",
+      "integrity": "sha512-ii/W7fwO4chNQVYl1C/8k7RW8EXzLb69rvg08p8mSJx8B2UasVJ9tuJpTH2Spo1jX6N3H0dKPWUbd1fAmdAhPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.13.1",
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "@cspell/dynamic-import": "8.13.1",
-        "@cspell/url": "8.13.1",
+        "@cspell/cspell-json-reporter": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "@cspell/dynamic-import": "8.14.2",
+        "@cspell/url": "8.14.2",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.13.1",
-        "cspell-gitignore": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-io": "8.13.1",
-        "cspell-lib": "8.13.1",
+        "cspell-dictionary": "8.14.2",
+        "cspell-gitignore": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-io": "8.14.2",
+        "cspell-lib": "8.14.2",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.0.0",
@@ -3396,13 +3475,14 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.13.1.tgz",
-      "integrity": "sha512-sXUFOyxvk+qDkoQdFkVEqj1hfQWzMi+tbi6ksiotQaqpm7r+YitZLSgwJjN4xgDO/rTLyP70k9fagdZ67MVZbw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.14.2.tgz",
+      "integrity": "sha512-yHP1BdcH5dbjb8qiZr6+bxEnJ+rxTULQ00wBz3eBPWCghJywEAYYvMWoYuxVtPpndlkKYC1wJAHsyNkweQyepA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.13.1",
-        "comment-json": "^4.2.4",
+        "@cspell/cspell-types": "8.14.2",
+        "comment-json": "^4.2.5",
         "yaml": "^2.5.0"
       },
       "engines": {
@@ -3410,14 +3490,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.13.1.tgz",
-      "integrity": "sha512-Z0T4J4ahOJaHmWq83w24KXGik1zeauO5WvDRyzDyaSgpbA5MN2hN98LvxaIx72g3I+trtRK77XFcKginuME9EA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.14.2.tgz",
+      "integrity": "sha512-gWuAvf6queGGUvGbfAxxUq55cZ0OevWPbjnCrSB0PpJ4tqdFd8dLcvVrIKzoE2sBXKPw2NDkmoEngs6iGavC0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "cspell-trie-lib": "8.13.1",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "cspell-trie-lib": "8.14.2",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -3425,14 +3506,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.13.1.tgz",
-      "integrity": "sha512-XyZ3X5d6x0gkWtNXSAQRcPMG41bEdLx9cTgZCYCJhEZCesU1VpNm60F3oc11dMLkO+BqPH3An+AO/YEIiaje3A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.14.2.tgz",
+      "integrity": "sha512-lrO/49NaKBpkR7vFxv4OOY+oHmsG5+gNQejrBBWD9Nv9vvjJtz/G36X/rcN6M6tFcQQMWwa01kf04nxz8Ejuhg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-io": "8.13.1",
+        "@cspell/url": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-io": "8.14.2",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -3443,12 +3525,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.13.1.tgz",
-      "integrity": "sha512-rW1A3t7YvPXxcC4z1pp1m9coeWzUVUmRjUw3vMNGlEDC2zecB39KKbEqesziBqnBceNAY7O5itllIGFKr03vqA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.14.2.tgz",
+      "integrity": "sha512-9Q1Kgoo1ev3fKTpp9y5n8M4RLxd8B0f5o4y5FQe4dBU0j/bt+/YDrLZNWDm77JViV606XQ6fimG1FTTq6pT9/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.13.1",
+        "@cspell/url": "8.14.2",
         "micromatch": "^4.0.7"
       },
       "engines": {
@@ -3456,13 +3539,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.13.1.tgz",
-      "integrity": "sha512-HUkd24bulvBwee1UNBurxGlPUOiywb9pB34iXXoxFWuloHohZ/DuFlE8B/31ZtjW48ffEYIu3QZfWhcnD8e81w==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.14.2.tgz",
+      "integrity": "sha512-eYwceVP80FGYVJenE42ALnvEKOXaXjq4yVbb1Ni1umO/9qamLWNCQ1RP6rRACy5e/cXviAbhrQ5Mtw6n+pyPEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1"
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -3472,39 +3556,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.13.1.tgz",
-      "integrity": "sha512-t2sgZuWGBzPSOAStfvz/U3KoFEfDxEt1cXZj0Kd0Vs36v2uoLktm6ihMe7XNFu7zIdOFSajsYQ8Bi4RSLPGPxQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.14.2.tgz",
+      "integrity": "sha512-uaKpHiY3DAgfdzgKMQml6U8F8o9udMuYxGqYa5FVfN7D5Ap7B2edQzSLTUYwxrFEn4skSfp6XY73+nzJvxzH4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.13.1",
-        "@cspell/url": "8.13.1"
+        "@cspell/cspell-service-bus": "8.14.2",
+        "@cspell/url": "8.14.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.13.1.tgz",
-      "integrity": "sha512-H1HHG1pmATSeAaY0KmQ0xnkbSqJLvh9QpXWARDLWKUBvtE+/l44H4yVhIp/No3rM7PKMmb82GuSJzMaoIhHFLQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.14.2.tgz",
+      "integrity": "sha512-d2oiIXHXnADmnhIuFLOdNE63L7OUfzgpLbYaqAWbkImCUDkevfGrOgnX8TJ03fUgZID4nvQ+3kgu/n2j4eLZjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.13.1",
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-resolver": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "@cspell/dynamic-import": "8.13.1",
-        "@cspell/strong-weak-map": "8.13.1",
-        "@cspell/url": "8.13.1",
+        "@cspell/cspell-bundled-dicts": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-resolver": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "@cspell/dynamic-import": "8.14.2",
+        "@cspell/filetypes": "8.14.2",
+        "@cspell/strong-weak-map": "8.14.2",
+        "@cspell/url": "8.14.2",
         "clear-module": "^4.1.2",
-        "comment-json": "^4.2.4",
-        "cspell-config-lib": "8.13.1",
-        "cspell-dictionary": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-grammar": "8.13.1",
-        "cspell-io": "8.13.1",
-        "cspell-trie-lib": "8.13.1",
+        "comment-json": "^4.2.5",
+        "cspell-config-lib": "8.14.2",
+        "cspell-dictionary": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-grammar": "8.14.2",
+        "cspell-io": "8.14.2",
+        "cspell-trie-lib": "8.14.2",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -3518,26 +3605,15 @@
         "node": ">=18"
       }
     },
-    "node_modules/cspell-lib/node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cspell-trie-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.13.1.tgz",
-      "integrity": "sha512-2moCsIYDmMT7hp5Non3CvWatfXptFWCuxjbXQGDNvWJ2Cj3oso/oBe4802GJv5GEenv9QBWmEtum/E7rFcx4JA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.14.2.tgz",
+      "integrity": "sha512-rZMbaEBGoyy4/zxKECaMyVyGLbuUxYmZ5jlEgiA3xPtEdWwJ4iWRTo5G6dWbQsXoxPYdAXXZ0/q0GQ2y6Jt0kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -3782,6 +3858,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -4161,10 +4250,11 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.7.0.tgz",
-      "integrity": "sha512-fzPGN7awL2ftVRQh/bsCi+16ArUZWujZnD1b8EGJqy8nr4//7tZ3BIdc/9edcJBtB3hpci3GtdMNFVDwHU0Eag==",
+      "version": "28.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.0.tgz",
+      "integrity": "sha512-Tubj1hooFxCl52G4qQu0edzV/+EZzPUeN8p2NnW5uu4fbDs+Yo7+qDVDc4/oG3FbCqEBmu/OC3LSsyiU22oghw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -4186,15 +4276,16 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "48.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
-      "integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
+      "version": "50.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.2.tgz",
+      "integrity": "sha512-i0ZMWA199DG7sjxlzXn5AeYZxpRfMJjDPUl7lL9eJJX8TPRoIaxJU4ys/joP5faM5AXE1eqW/dslCj3uj4Nqpg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.46.0",
+        "@es-joy/jsdoccomment": "~0.48.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "escape-string-regexp": "^4.0.0",
         "espree": "^10.1.0",
         "esquery": "^1.6.0",
@@ -4578,6 +4669,7 @@
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
       "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4741,6 +4833,7 @@
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
       "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4847,6 +4940,7 @@
       "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
       "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4974,6 +5068,7 @@
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
       "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ini": "4.1.1"
       },
@@ -4982,15 +5077,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/global-directory/node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/globals": {
@@ -5111,6 +5197,7 @@
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5263,6 +5350,7 @@
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
       "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5292,6 +5380,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -7027,10 +7125,11 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7453,10 +7552,11 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.0.2.tgz",
-      "integrity": "sha512-uX7/Lel+0P3sVuTTr9G3u+8qPJQw9Yl9FtpW8TNpuAMziN+au/Mspqo2g1Sd+3M6MFlSNX2Q3KI0tMW47WP5LQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.0.tgz",
+      "integrity": "sha512-RcohCA/tdpxyPllBlYDkqGXFJQgTuEt0f2oPSL9s05pZ3hxYdleaUtvEcSxKl0XAg3ncBhVgLAxhXSjoryUU5Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
         "npm-check-updates": "build/cli.js"
@@ -7799,6 +7899,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
       "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.1.0"
       },
@@ -8315,6 +8416,7 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -9354,13 +9456,15 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walk-back": {
       "version": "5.1.0",
@@ -9469,6 +9573,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
       "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -9501,6 +9606,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
       "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -78,18 +78,18 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "cspell": "^8.13.1",
+    "cspell": "^8.14.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jest": "^28.7.0",
-    "eslint-plugin-jsdoc": "^48.11.0",
+    "eslint-plugin-jest": "^28.8.0",
+    "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "jsdoc-to-markdown": "^8.0.3",
-    "npm-check-updates": "^17.0.2",
+    "npm-check-updates": "^17.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3"
   }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps-dev): bump group with 4 updates
   * cspell from 8.13.1 to 8.14.2
   * eslint-plugin-jest from 28.7.0 to 28.8.0
   * eslint-plugin-jsdoc from 48.11.0 to 50.2.2
   * npm-check-updates from 17.0.2 to 17.1.0

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean

<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing