### PR TITLE
build(deps-dev): bump group with 3 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
         "changelog": "bin/cli.js"
       },
       "devDependencies": {
-        "cspell": "^8.14.4",
+        "cspell": "^8.15.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
-        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.8.3",
-        "eslint-plugin-jsdoc": "^50.3.1",
+        "eslint-plugin-jsdoc": "^50.4.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
@@ -645,95 +645,99 @@
       "license": "MIT"
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.14.4.tgz",
-      "integrity": "sha512-JHZOpCJzN6fPBapBOvoeMxZbr0ZA11ZAkwcqM4w0lKoacbi6TwK8GIYf66hHvwLmMeav75TNXWE6aPTvBLMMqA==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.15.2.tgz",
+      "integrity": "sha512-e+hxoD/GW7iyK1zMeRFd10yBr9tcClnnqFLxJM+tH1cSzLQ66ouXMIMuJpcd8LOCm7zMRdjTm4R72LehMgL79g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/dict-ada": "^4.0.2",
-        "@cspell/dict-aws": "^4.0.4",
-        "@cspell/dict-bash": "^4.1.4",
-        "@cspell/dict-companies": "^3.1.4",
-        "@cspell/dict-cpp": "^5.1.16",
-        "@cspell/dict-cryptocurrencies": "^5.0.0",
-        "@cspell/dict-csharp": "^4.0.2",
-        "@cspell/dict-css": "^4.0.13",
-        "@cspell/dict-dart": "^2.2.1",
-        "@cspell/dict-django": "^4.1.0",
-        "@cspell/dict-docker": "^1.1.7",
-        "@cspell/dict-dotnet": "^5.0.5",
-        "@cspell/dict-elixir": "^4.0.3",
-        "@cspell/dict-en_us": "^4.3.23",
-        "@cspell/dict-en-common-misspellings": "^2.0.4",
+        "@cspell/dict-ada": "^4.0.5",
+        "@cspell/dict-aws": "^4.0.7",
+        "@cspell/dict-bash": "^4.1.8",
+        "@cspell/dict-companies": "^3.1.7",
+        "@cspell/dict-cpp": "^5.1.22",
+        "@cspell/dict-cryptocurrencies": "^5.0.3",
+        "@cspell/dict-csharp": "^4.0.5",
+        "@cspell/dict-css": "^4.0.16",
+        "@cspell/dict-dart": "^2.2.4",
+        "@cspell/dict-django": "^4.1.3",
+        "@cspell/dict-docker": "^1.1.10",
+        "@cspell/dict-dotnet": "^5.0.8",
+        "@cspell/dict-elixir": "^4.0.6",
+        "@cspell/dict-en_us": "^4.3.26",
+        "@cspell/dict-en-common-misspellings": "^2.0.7",
         "@cspell/dict-en-gb": "1.1.33",
-        "@cspell/dict-filetypes": "^3.0.4",
-        "@cspell/dict-flutter": "^1.0.0",
-        "@cspell/dict-fonts": "^4.0.0",
-        "@cspell/dict-fsharp": "^1.0.1",
-        "@cspell/dict-fullstack": "^3.2.0",
-        "@cspell/dict-gaming-terms": "^1.0.5",
-        "@cspell/dict-git": "^3.0.0",
-        "@cspell/dict-golang": "^6.0.12",
-        "@cspell/dict-google": "^1.0.1",
-        "@cspell/dict-haskell": "^4.0.1",
-        "@cspell/dict-html": "^4.0.5",
-        "@cspell/dict-html-symbol-entities": "^4.0.0",
-        "@cspell/dict-java": "^5.0.7",
-        "@cspell/dict-julia": "^1.0.1",
-        "@cspell/dict-k8s": "^1.0.6",
-        "@cspell/dict-latex": "^4.0.0",
-        "@cspell/dict-lorem-ipsum": "^4.0.0",
-        "@cspell/dict-lua": "^4.0.3",
-        "@cspell/dict-makefile": "^1.0.0",
-        "@cspell/dict-monkeyc": "^1.0.6",
-        "@cspell/dict-node": "^5.0.1",
-        "@cspell/dict-npm": "^5.1.4",
-        "@cspell/dict-php": "^4.0.10",
-        "@cspell/dict-powershell": "^5.0.8",
-        "@cspell/dict-public-licenses": "^2.0.8",
-        "@cspell/dict-python": "^4.2.6",
-        "@cspell/dict-r": "^2.0.1",
-        "@cspell/dict-ruby": "^5.0.3",
-        "@cspell/dict-rust": "^4.0.5",
-        "@cspell/dict-scala": "^5.0.3",
-        "@cspell/dict-software-terms": "^4.1.3",
-        "@cspell/dict-sql": "^2.1.5",
-        "@cspell/dict-svelte": "^1.0.2",
-        "@cspell/dict-swift": "^2.0.1",
-        "@cspell/dict-terraform": "^1.0.1",
-        "@cspell/dict-typescript": "^3.1.6",
-        "@cspell/dict-vue": "^3.0.0"
+        "@cspell/dict-filetypes": "^3.0.7",
+        "@cspell/dict-flutter": "^1.0.3",
+        "@cspell/dict-fonts": "^4.0.3",
+        "@cspell/dict-fsharp": "^1.0.4",
+        "@cspell/dict-fullstack": "^3.2.3",
+        "@cspell/dict-gaming-terms": "^1.0.8",
+        "@cspell/dict-git": "^3.0.3",
+        "@cspell/dict-golang": "^6.0.16",
+        "@cspell/dict-google": "^1.0.4",
+        "@cspell/dict-haskell": "^4.0.4",
+        "@cspell/dict-html": "^4.0.9",
+        "@cspell/dict-html-symbol-entities": "^4.0.3",
+        "@cspell/dict-java": "^5.0.10",
+        "@cspell/dict-julia": "^1.0.4",
+        "@cspell/dict-k8s": "^1.0.9",
+        "@cspell/dict-latex": "^4.0.3",
+        "@cspell/dict-lorem-ipsum": "^4.0.3",
+        "@cspell/dict-lua": "^4.0.6",
+        "@cspell/dict-makefile": "^1.0.3",
+        "@cspell/dict-monkeyc": "^1.0.9",
+        "@cspell/dict-node": "^5.0.4",
+        "@cspell/dict-npm": "^5.1.8",
+        "@cspell/dict-php": "^4.0.13",
+        "@cspell/dict-powershell": "^5.0.13",
+        "@cspell/dict-public-licenses": "^2.0.11",
+        "@cspell/dict-python": "^4.2.11",
+        "@cspell/dict-r": "^2.0.4",
+        "@cspell/dict-ruby": "^5.0.7",
+        "@cspell/dict-rust": "^4.0.9",
+        "@cspell/dict-scala": "^5.0.6",
+        "@cspell/dict-software-terms": "^4.1.10",
+        "@cspell/dict-sql": "^2.1.8",
+        "@cspell/dict-svelte": "^1.0.5",
+        "@cspell/dict-swift": "^2.0.4",
+        "@cspell/dict-terraform": "^1.0.5",
+        "@cspell/dict-typescript": "^3.1.9",
+        "@cspell/dict-vue": "^3.0.3"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.14.4.tgz",
-      "integrity": "sha512-gJ6tQbGCNLyHS2iIimMg77as5MMAFv3sxU7W6tjLlZp8htiNZS7fS976g24WbT/hscsTT9Dd0sNHkpo8K3nvVw==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.15.2.tgz",
+      "integrity": "sha512-6p9eLdO5RLb1HNf+Rto4RG3tG02y05DutrWdpnK1Agn21EbUKAUIdIcsjQ2N52UeVT5cDvNhkAabKN57sFygag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.14.4"
+        "@cspell/cspell-types": "8.15.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.14.4.tgz",
-      "integrity": "sha512-CLLdouqfrQ4rqdQdPu0Oo+HHCU/oLYoEsK1nNPb28cZTFxnn0cuSPKB6AMPBJmMwdfJ6fMD0BCKNbEe1UNLHcw==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.15.2.tgz",
+      "integrity": "sha512-TOcLiRiUSh75y+DQrAW59Ix0/D9WPrd4/KPtUShUepS3vLfoxMQ+TwpXfdc8FrzU73Hg5glXXnQjvdx7vAazVQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.14.4.tgz",
-      "integrity": "sha512-s3uZyymJ04yn8+zlTp7Pt1WRSlAel6XVo+iZRxls3LSvIP819KK64DoyjCD2Uon0Vg9P/K7aAPt8GcxDcnJtgA==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.15.2.tgz",
+      "integrity": "sha512-XOcHfkKCN+a3zZMexK/BLmDxsqku8Q5ASqYu7JBFsu/axS4K11bkcQMxYoOvHVGBv20vb/gM2D+9MePuxAfssg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "global-directory": "^4.0.1"
       },
@@ -742,355 +746,412 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.14.4.tgz",
-      "integrity": "sha512-i3UG+ep63akNsDXZrtGgICNF3MLBHtvKe/VOIH6+L+NYaAaVHqqQvOY9MdUwt1HXh8ElzfwfoRp36wc5aAvt6g==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.15.2.tgz",
+      "integrity": "sha512-g9rhMIU0DX+avIQHFu0Mx3LAFi4lG6zX8iFa2zu+u3ll0IX0WtxTqrzft27jYSwebmm/ysWJUcOY+SWhZfPA0Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.14.4.tgz",
-      "integrity": "sha512-VXwikqdHgjOVperVVCn2DOe8W3rPIswwZtMHfRYnagpzZo/TOntIjkXPJSfTtl/cFyx5DnCBsDH8ytKGlMeHkw==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.15.2.tgz",
+      "integrity": "sha512-bHAkXsrfOhKyZZ+TA5eGH3fqh9DPcP3a2v+ozTnhhZa3zcfuzX7rZnYWEFA8LELMUStWXLECzFoGd9QUEHMstg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/dict-ada": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.2.tgz",
-      "integrity": "sha512-0kENOWQeHjUlfyId/aCM/mKXtkEgV0Zu2RhUXCBr4hHo9F9vph+Uu8Ww2b0i5a4ZixoIkudGA+eJvyxrG1jUpA==",
-      "dev": true
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.5.tgz",
+      "integrity": "sha512-6/RtZ/a+lhFVmrx/B7bfP7rzC4yjEYe8o74EybXcvu4Oue6J4Ey2WSYj96iuodloj1LWrkNCQyX5h4Pmcj0Iag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.4.tgz",
-      "integrity": "sha512-6AWI/Kkf+RcX/J81VX8+GKLeTgHWEr/OMhGk3dHQzWK66RaqDJCGDqi7494ghZKcBB7dGa3U5jcKw2FZHL/u3w==",
-      "dev": true
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.7.tgz",
+      "integrity": "sha512-PoaPpa2NXtSkhGIMIKhsJUXB6UbtTt6Ao3x9JdU9kn7fRZkwD4RjHDGqulucIOz7KeEX/dNRafap6oK9xHe4RA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-bash": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.4.tgz",
-      "integrity": "sha512-W/AHoQcJYn3Vn/tUiXX2+6D/bhfzdDshwcbQWv9TdiNlXP9P6UJjDKWbxyA5ogJCsR2D0X9Kx11oV8E58siGKQ==",
-      "dev": true
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.8.tgz",
+      "integrity": "sha512-I2CM2pTNthQwW069lKcrVxchJGMVQBzru2ygsHCwgidXRnJL/NTjAPOFTxN58Jc1bf7THWghfEDyKX/oyfc0yg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.4.tgz",
-      "integrity": "sha512-y9e0amzEK36EiiKx3VAA+SHQJPpf2Qv5cCt5eTUSggpTkiFkCh6gRKQ97rVlrKh5GJrqinDwYIJtTsxuh2vy2Q==",
-      "dev": true
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.7.tgz",
+      "integrity": "sha512-ncVs/efuAkP1/tLDhWbXukBjgZ5xOUfe03neHMWsE8zvXXc5+Lw6TX5jaJXZLOoES/f4j4AhRE20jsPCF5pm+A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.16.tgz",
-      "integrity": "sha512-32fU5RkuOM55IRcxjByiSoKbjr+C4danDfYjHaQNRWdvjzJzci3fLDGA2wTXiclkgDODxGiV8LCTUwCz+3TNWA==",
-      "dev": true
+      "version": "5.1.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.22.tgz",
+      "integrity": "sha512-g1/8P5/Q+xnIc8Js4UtBg3XOhcFrFlFbG3UWVtyEx49YTf0r9eyDtDt1qMMDBZT91pyCwLcAEbwS+4i5PIfNZw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.0.tgz",
-      "integrity": "sha512-Z4ARIw5+bvmShL+4ZrhDzGhnc9znaAGHOEMaB/GURdS/jdoreEDY34wdN0NtdLHDO5KO7GduZnZyqGdRoiSmYA==",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.3.tgz",
+      "integrity": "sha512-bl5q+Mk+T3xOZ12+FG37dB30GDxStza49Rmoax95n37MTLksk9wBo1ICOlPJ6PnDUSyeuv4SIVKgRKMKkJJglA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-csharp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.2.tgz",
-      "integrity": "sha512-1JMofhLK+4p4KairF75D3A924m5ERMgd1GvzhwK2geuYgd2ZKuGW72gvXpIV7aGf52E3Uu1kDXxxGAiZ5uVG7g==",
-      "dev": true
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.5.tgz",
+      "integrity": "sha512-c/sFnNgtRwRJxtC3JHKkyOm+U3/sUrltFeNwml9VsxKBHVmvlg4tk4ar58PdpW9/zTlGUkWi2i85//DN1EsUCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.13.tgz",
-      "integrity": "sha512-WfOQkqlAJTo8eIQeztaH0N0P+iF5hsJVKFuhy4jmARPISy8Efcv8QXk2/IVbmjJH0/ZV7dKRdnY5JFVXuVz37g==",
-      "dev": true
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.16.tgz",
+      "integrity": "sha512-70qu7L9z/JR6QLyJPk38fNTKitlIHnfunx0wjpWQUQ8/jGADIhMCrz6hInBjqPNdtGpYm8d1dNFyF8taEkOgrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.2.1.tgz",
-      "integrity": "sha512-yriKm7QkoPx3JPSSOcw6iX9gOb2N50bOo/wqWviqPYbhpMRh9Xiv6dkUy3+ot+21GuShZazO8X6U5+Vw67XEwg==",
-      "dev": true
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.2.4.tgz",
+      "integrity": "sha512-of/cVuUIZZK/+iqefGln8G3bVpfyN6ZtH+LyLkHMoR5tEj+2vtilGNk9ngwyR8L4lEqbKuzSkOxgfVjsXf5PsQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-data-science": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.1.tgz",
-      "integrity": "sha512-xeutkzK0eBe+LFXOFU2kJeAYO6IuFUc1g7iRLr7HeCmlC4rsdGclwGHh61KmttL3+YHQytYStxaRBdGAXWC8Lw==",
-      "dev": true
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.5.tgz",
+      "integrity": "sha512-nNSILXmhSJox9/QoXICPQgm8q5PbiSQP4afpbkBqPi/u/b3K9MbNH5HvOOa6230gxcGdbZ9Argl2hY/U8siBlg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-django": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.0.tgz",
-      "integrity": "sha512-bKJ4gPyrf+1c78Z0Oc4trEB9MuhcB+Yg+uTTWsvhY6O2ncFYbB/LbEZfqhfmmuK/XJJixXfI1laF2zicyf+l0w==",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.3.tgz",
+      "integrity": "sha512-yBspeL3roJlO0a1vKKNaWABURuHdHZ9b1L8d3AukX0AsBy9snSggc8xCavPmSzNfeMDXbH+1lgQiYBd3IW03fg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-docker": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.7.tgz",
-      "integrity": "sha512-XlXHAr822euV36GGsl2J1CkBIVg3fZ6879ZOg5dxTIssuhUOCiV2BuzKZmt6aIFmcdPmR14+9i9Xq+3zuxeX0A==",
-      "dev": true
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.10.tgz",
+      "integrity": "sha512-vWybMfsG/8jhN6kmPoilMon36GB3+Ef+m/mgYUfY8tJN23K/x4KD1rU1OOiNWzDqePhu3MMWVKO5W5x6VI6Gbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.5.tgz",
-      "integrity": "sha512-gjg0L97ee146wX47dnA698cHm85e7EOpf9mVrJD8DmEaqoo/k1oPy2g7c7LgKxK9XnqwoXxhLNnngPrwXOoEtQ==",
-      "dev": true
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.8.tgz",
+      "integrity": "sha512-MD8CmMgMEdJAIPl2Py3iqrx3B708MbCIXAuOeZ0Mzzb8YmLmiisY7QEYSZPg08D7xuwARycP0Ki+bb0GAkFSqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-elixir": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.3.tgz",
-      "integrity": "sha512-g+uKLWvOp9IEZvrIvBPTr/oaO6619uH/wyqypqvwpmnmpjcfi8+/hqZH8YNKt15oviK8k4CkINIqNhyndG9d9Q==",
-      "dev": true
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.6.tgz",
+      "integrity": "sha512-TfqSTxMHZ2jhiqnXlVKM0bUADtCvwKQv2XZL/DI0rx3doG8mEMS8SGPOmiyyGkHpR/pGOq18AFH3BEm4lViHIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.23.tgz",
-      "integrity": "sha512-l0SoEQBsi3zDSl3OuL4/apBkxjuj4hLIg/oy6+gZ7LWh03rKdF6VNtSZNXWAmMY+pmb1cGA3ouleTiJIglbsIg==",
-      "dev": true
+      "version": "4.3.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.26.tgz",
+      "integrity": "sha512-hDbHYJsi3UgU1J++B0WLiYhWQdsmve3CH53FIaMRAdhrWOHcuw7h1dYkQXHFEP5lOjaq53KUHp/oh5su6VkIZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.4.tgz",
-      "integrity": "sha512-lvOiRjV/FG4pAGZL3PN2GCVHSTCE92cwhfLGGkOsQtxSmef6WCHfHwp9auafkBlX0yFQSKDfq6/TlpQbjbJBtQ==",
-      "dev": true
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.7.tgz",
+      "integrity": "sha512-qNFo3G4wyabcwnM+hDrMYKN9vNVg/k9QkhqSlSst6pULjdvPyPs1mqz1689xO/v9t8e6sR4IKc3CgUXDMTYOpA==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
       "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.4.tgz",
-      "integrity": "sha512-IBi8eIVdykoGgIv5wQhOURi5lmCNJq0we6DvqKoPQJHthXbgsuO1qrHSiUVydMiQl/XvcnUWTMeAlVUlUClnVg==",
-      "dev": true
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.7.tgz",
+      "integrity": "sha512-/DN0Ujp9/EXvpTcgih9JmBaE8n+G0wtsspyNdvHT5luRfpfol1xm/CIQb6xloCXCiLkWX+EMPeLSiVIZq+24dA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-flutter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.0.tgz",
-      "integrity": "sha512-W7k1VIc4KeV8BjEBxpA3cqpzbDWjfb7oXkEb0LecBCBp5Z7kcfnjT1YVotTx/U9PGyAOBhDaEdgZACVGNQhayw==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.3.tgz",
+      "integrity": "sha512-52C9aUEU22ptpgYh6gQyIdA4MP6NPwzbEqndfgPh3Sra191/kgs7CVqXiO1qbtZa9gnYHUoVApkoxRE7mrXHfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fonts": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.0.tgz",
-      "integrity": "sha512-t9V4GeN/m517UZn63kZPUYP3OQg5f0OBLSd3Md5CU3eH1IFogSvTzHHnz4Wqqbv8NNRiBZ3HfdY/pqREZ6br3Q==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.3.tgz",
+      "integrity": "sha512-sPd17kV5qgYXLteuHFPn5mbp/oCHKgitNfsZLFC3W2fWEgZlhg4hK+UGig3KzrYhhvQ8wBnmZrAQm0TFKCKzsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fsharp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.1.tgz",
-      "integrity": "sha512-23xyPcD+j+NnqOjRHgW3IU7Li912SX9wmeefcY0QxukbAxJ/vAN4rBpjSwwYZeQPAn3fxdfdNZs03fg+UM+4yQ==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.4.tgz",
+      "integrity": "sha512-G5wk0o1qyHUNi9nVgdE1h5wl5ylq7pcBjX8vhjHcO4XBq20D5eMoXjwqMo/+szKAqzJ+WV3BgAL50akLKrT9Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.0.tgz",
-      "integrity": "sha512-sIGQwU6G3rLTo+nx0GKyirR5dQSFeTIzFTOrURw51ISf+jKG9a3OmvsVtc2OANfvEAOLOC9Wfd8WYhmsO8KRDQ==",
-      "dev": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.3.tgz",
+      "integrity": "sha512-62PbndIyQPH11mAv0PyiyT0vbwD0AXEocPpHlCHzfb5v9SspzCCbzQ/LIBiFmyRa+q5LMW35CnSVu6OXdT+LKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-gaming-terms": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.5.tgz",
-      "integrity": "sha512-C3riccZDD3d9caJQQs1+MPfrUrQ+0KHdlj9iUR1QD92FgTOF6UxoBpvHUUZ9YSezslcmpFQK4xQQ5FUGS7uWfw==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.8.tgz",
+      "integrity": "sha512-7OL0zTl93WFWhhtpXFrtm9uZXItC3ncAs8d0iQDMMFVNU1rBr6raBNxJskxE5wx2Ant12fgI66ZGVagXfN+yfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-git": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.0.tgz",
-      "integrity": "sha512-simGS/lIiXbEaqJu9E2VPoYW1OTC2xrwPPXNXFMa2uo/50av56qOuaxDrZ5eH1LidFXwoc8HROCHYeKoNrDLSw==",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.3.tgz",
+      "integrity": "sha512-LSxB+psZ0qoj83GkyjeEH/ZViyVsGEF/A6BAo8Nqc0w0HjD2qX/QR4sfA6JHUgQ3Yi/ccxdK7xNIo67L2ScW5A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.12.tgz",
-      "integrity": "sha512-LEPeoqd+4O+vceHF73S7D7+LYfrAjOvp4Dqzh4MT30ruzlQ77yHRSuYOJtrFN1GK5ntAt/ILSVOKg9sgsz1Llg==",
-      "dev": true
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.16.tgz",
+      "integrity": "sha512-hZOBlgcguv2Hdc93n2zjdAQm1j3grsN9T9WhPnQ1wh2vUDoCLEujg+6gWhjcLb8ECOcwZTWgNyQLWeOxEsAj/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-google": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.1.tgz",
-      "integrity": "sha512-dQr4M3n95uOhtloNSgB9tYYGXGGEGEykkFyRtfcp5pFuEecYUa0BSgtlGKx9RXVtJtKgR+yFT/a5uQSlt8WjqQ==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.4.tgz",
+      "integrity": "sha512-JThUT9eiguCja1mHHLwYESgxkhk17Gv7P3b1S7ZJzXw86QyVHPrbpVoMpozHk0C9o+Ym764B7gZGKmw9uMGduQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-haskell": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.1.tgz",
-      "integrity": "sha512-uRrl65mGrOmwT7NxspB4xKXFUenNC7IikmpRZW8Uzqbqcu7ZRCUfstuVH7T1rmjRgRkjcIjE4PC11luDou4wEQ==",
-      "dev": true
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.4.tgz",
+      "integrity": "sha512-EwQsedEEnND/vY6tqRfg9y7tsnZdxNqOxLXSXTsFA6JRhUlr8Qs88iUUAfsUzWc4nNmmzQH2UbtT25ooG9x4nA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.6.tgz",
-      "integrity": "sha512-cLWHfuOhE4wqwC12up6Doxo2u1xxVhX1A8zriR4CUD+osFQzUIcBK1ykNXppga+rt1WyypaJdTU2eV6OpzYrgQ==",
-      "dev": true
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.9.tgz",
+      "integrity": "sha512-BNp7w3m910K4qIVyOBOZxHuFNbVojUY6ES8Y8r7YjYgJkm2lCuQoVwwhPjurnomJ7BPmZTb+3LLJ58XIkgF7JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.0.tgz",
-      "integrity": "sha512-HGRu+48ErJjoweR5IbcixxETRewrBb0uxQBd6xFGcxbEYCX8CnQFTAmKI5xNaIt2PKaZiJH3ijodGSqbKdsxhw==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.3.tgz",
+      "integrity": "sha512-aABXX7dMLNFdSE8aY844X4+hvfK7977sOWgZXo4MTGAmOzR8524fjbJPswIBK7GaD3+SgFZ2yP2o0CFvXDGF+A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.7.tgz",
-      "integrity": "sha512-ejQ9iJXYIq7R09BScU2y5OUGrSqwcD+J5mHFOKbduuQ5s/Eh/duz45KOzykeMLI6KHPVxhBKpUPBWIsfewECpQ==",
-      "dev": true
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.10.tgz",
+      "integrity": "sha512-pVNcOnmoGiNL8GSVq4WbX/Vs2FGS0Nej+1aEeGuUY9CU14X8yAVCG+oih5ZoLt1jaR8YfR8byUF8wdp4qG4XIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-julia": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.1.tgz",
-      "integrity": "sha512-4JsCLCRhhLMLiaHpmR7zHFjj1qOauzDI5ZzCNQS31TUMfsOo26jAKDfo0jljFAKgw5M2fEG7sKr8IlPpQAYrmQ==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.4.tgz",
+      "integrity": "sha512-bFVgNX35MD3kZRbXbJVzdnN7OuEqmQXGpdOi9jzB40TSgBTlJWA4nxeAKV4CPCZxNRUGnLH0p05T/AD7Aom9/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-k8s": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.6.tgz",
-      "integrity": "sha512-srhVDtwrd799uxMpsPOQqeDJY+gEocgZpoK06EFrb4GRYGhv7lXo9Fb+xQMyQytzOW9dw4DNOEck++nacDuymg==",
-      "dev": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.9.tgz",
+      "integrity": "sha512-Q7GELSQIzo+BERl2ya/nBEnZeQC+zJP19SN1pI6gqDYraM51uYJacbbcWLYYO2Y+5joDjNt/sd/lJtLaQwoSlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-latex": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.0.tgz",
-      "integrity": "sha512-LPY4y6D5oI7D3d+5JMJHK/wxYTQa2lJMSNxps2JtuF8hbAnBQb3igoWEjEbIbRRH1XBM0X8dQqemnjQNCiAtxQ==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.3.tgz",
+      "integrity": "sha512-2KXBt9fSpymYHxHfvhUpjUFyzrmN4c4P8mwIzweLyvqntBT3k0YGZJSriOdjfUjwSygrfEwiuPI1EMrvgrOMJw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lorem-ipsum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.0.tgz",
-      "integrity": "sha512-1l3yjfNvMzZPibW8A7mQU4kTozwVZVw0AvFEdy+NcqtbxH+TvbSkNMqROOFWrkD2PjnKG0+Ea0tHI2Pi6Gchnw==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.3.tgz",
+      "integrity": "sha512-WFpDi/PDYHXft6p0eCXuYnn7mzMEQLVeqpO+wHSUd+kz5ADusZ4cpslAA4wUZJstF1/1kMCQCZM6HLZic9bT8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lua": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.3.tgz",
-      "integrity": "sha512-lDHKjsrrbqPaea13+G9s0rtXjMO06gPXPYRjRYawbNmo4E/e3XFfVzeci3OQDQNDmf2cPOwt9Ef5lu2lDmwfJg==",
-      "dev": true
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.6.tgz",
+      "integrity": "sha512-Jwvh1jmAd9b+SP9e1GkS2ACbqKKRo9E1f9GdjF/ijmooZuHU0hPyqvnhZzUAxO1egbnNjxS/J2T6iUtjAUK2KQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-makefile": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.0.tgz",
-      "integrity": "sha512-3W9tHPcSbJa6s0bcqWo6VisEDTSN5zOtDbnPabF7rbyjRpNo0uHXHRJQF8gAbFzoTzBBhgkTmrfSiuyQm7vBUQ==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.3.tgz",
+      "integrity": "sha512-R3U0DSpvTs6qdqfyBATnePj9Q/pypkje0Nj26mQJ8TOBQutCRAJbr2ZFAeDjgRx5EAJU/+8txiyVF97fbVRViw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-monkeyc": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.6.tgz",
-      "integrity": "sha512-oO8ZDu/FtZ55aq9Mb67HtaCnsLn59xvhO/t2mLLTHAp667hJFxpp7bCtr2zOrR1NELzFXmKln/2lw/PvxMSvrA==",
-      "dev": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.9.tgz",
+      "integrity": "sha512-Jvf6g5xlB4+za3ThvenYKREXTEgzx5gMUSzrAxIiPleVG4hmRb/GBSoSjtkGaibN3XxGx5x809gSTYCA/IHCpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.1.tgz",
-      "integrity": "sha512-lax/jGz9h3Dv83v8LHa5G0bf6wm8YVRMzbjJPG/9rp7cAGPtdrga+XANFq+B7bY5+jiSA3zvj10LUFCFjnnCCg==",
-      "dev": true
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.4.tgz",
+      "integrity": "sha512-Hz5hiuOvZTd7Cp1IBqUZ7/ChwJeQpD5BJuwCaDn4mPNq4iMcQ1iWBYMThvNVqCEDgKv63X52nT8RAWacss98qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.5.tgz",
-      "integrity": "sha512-oAOGWuJYU3DlO+cAsStKMWN8YEkBue25cRC9EwdiL5Z84nchU20UIoYrLfIQejMlZca+1GyrNeyxRAgn4KiivA==",
-      "dev": true
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.8.tgz",
+      "integrity": "sha512-AJELYXeB4fQdIoNfmuaQxB1Hli3cX6XPsQCjfBxlu0QYXhrjB/IrCLLQAjWIywDqJiWyGUFTz4DqaANm8C/r9Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.10.tgz",
-      "integrity": "sha512-NfTZdp6kcZDF1PvgQ6cY0zE4FUO5rSwNmBH/iwCBuaLfJAFQ97rgjxo+D2bic4CFwNjyHutnHPtjJBRANO5XQw==",
-      "dev": true
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.13.tgz",
+      "integrity": "sha512-P6sREMZkhElzz/HhXAjahnICYIqB/HSGp1EhZh+Y6IhvC15AzgtDP8B8VYCIsQof6rPF1SQrFwunxOv8H1e2eg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-powershell": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.9.tgz",
-      "integrity": "sha512-Vi0h0rlxS39tgTyUtxI6L3BPHH7MLPkLWCYkNfb/buQuNJYNFdHiF4bqoqVdJ/7ZrfIfNg4i6rzocnwGRn2ruw==",
-      "dev": true
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.13.tgz",
+      "integrity": "sha512-0qdj0XZIPmb77nRTynKidRJKTU0Fl+10jyLbAhFTuBWKMypVY06EaYFnwhsgsws/7nNX8MTEQuewbl9bWFAbsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.8.tgz",
-      "integrity": "sha512-Sup+tFS7cDV0fgpoKtUqEZ6+fA/H+XUgBiqQ/Fbs6vUE3WCjJHOIVsP+udHuyMH7iBfJ4UFYOYeORcY4EaKdMg==",
-      "dev": true
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.11.tgz",
+      "integrity": "sha512-rR5KjRUSnVKdfs5G+gJ4oIvQvm8+NJ6cHWY2N+GE69/FSGWDOPHxulCzeGnQU/c6WWZMSimG9o49i9r//lUQyA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.6.tgz",
-      "integrity": "sha512-Hkz399qDGEbfXi9GYa2hDl7GahglI86JmS2F1KP8sfjLXofUgtnknyC5NWc86nzHcP38pZiPqPbTigyDYw5y8A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.11.tgz",
+      "integrity": "sha512-bshNZqP5FYRO0CtZ9GgtVjHidrSuRRF537MU/sPew8oaqWPg066F9KQfPllbRi9AzFqqeS2l7/ACYUrFMe21gw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/dict-data-science": "^2.0.1"
+        "@cspell/dict-data-science": "^2.0.5"
       }
     },
     "node_modules/@cspell/dict-r": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.1.tgz",
-      "integrity": "sha512-KCmKaeYMLm2Ip79mlYPc8p+B2uzwBp4KMkzeLd5E6jUlCL93Y5Nvq68wV5fRLDRTf7N1LvofkVFWfDcednFOgA==",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.4.tgz",
+      "integrity": "sha512-cBpRsE/U0d9BRhiNRMLMH1PpWgw+N+1A2jumgt1if9nBGmQw4MUpg2u9I0xlFVhstTIdzXiLXMxP45cABuiUeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.3.tgz",
-      "integrity": "sha512-V1xzv9hN6u8r6SM4CkYdsxs4ov8gjXXo0Twfx5kWhLXbEVxTXDMt7ohLTqpy2XlF5mutixZdbHMeFiAww8v+Ug==",
-      "dev": true
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.7.tgz",
+      "integrity": "sha512-4/d0hcoPzi5Alk0FmcyqlzFW9lQnZh9j07MJzPcyVO62nYJJAGKaPZL2o4qHeCS/od/ctJC5AHRdoUm0ktsw6Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.5.tgz",
-      "integrity": "sha512-DIvlPRDemjKQy8rCqftAgGNZxY5Bg+Ps7qAIJjxkSjmMETyDgl0KTVuaJPt7EK4jJt6uCZ4ILy96npsHDPwoXA==",
-      "dev": true
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.9.tgz",
+      "integrity": "sha512-Dhr6TIZsMV92xcikKIWei6p/qswS4M+gTkivpWwz4/1oaVk2nRrxJmCdRoVkJlZkkAc17rjxrS12mpnJZI0iWw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-scala": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.3.tgz",
-      "integrity": "sha512-4yGb4AInT99rqprxVNT9TYb1YSpq58Owzq7zi3ZS5T0u899Y4VsxsBiOgHnQ/4W+ygi+sp+oqef8w8nABR2lkg==",
-      "dev": true
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.6.tgz",
+      "integrity": "sha512-tl0YWAfjUVb4LyyE4JIMVE8DlLzb1ecHRmIWc4eT6nkyDqQgHKzdHsnusxFEFMVLIQomgSg0Zz6hJ5S1E4W4ww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.4.tgz",
-      "integrity": "sha512-AHS25sYEzWze/aFglp9ODKSu+phjkuGx+OLwIcmOnvyn8axtSq5GCn9UqS4XG1/Qn0UG2Lgb4i5PJbZ0QNPNXQ==",
-      "dev": true
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.10.tgz",
+      "integrity": "sha512-+9PuQ9MHQhlET6Hv1mGcWDh6Rb+StzjBMrjfksDeBHBIVdT66u9uCkaZapIzfgktflY4m9oK7+dEynr+BAxvtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-sql": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.5.tgz",
-      "integrity": "sha512-FmxanytHXss7GAWAXmgaxl3icTCW7YxlimyOSPNfm+njqeUDjw3kEv4mFNDDObBJv8Ec5AWCbUDkWIpkE3IpKg==",
-      "dev": true
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.8.tgz",
+      "integrity": "sha512-dJRE4JV1qmXTbbGm6WIcg1knmR6K5RXnQxF4XHs5HA3LAjc/zf77F95i5LC+guOGppVF6Hdl66S2UyxT+SAF3A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-svelte": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.2.tgz",
-      "integrity": "sha512-rPJmnn/GsDs0btNvrRBciOhngKV98yZ9SHmg8qI6HLS8hZKvcXc0LMsf9LLuMK1TmS2+WQFAan6qeqg6bBxL2Q==",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.5.tgz",
+      "integrity": "sha512-sseHlcXOqWE4Ner9sg8KsjxwSJ2yssoJNqFHR9liWVbDV+m7kBiUtn2EB690TihzVsEmDr/0Yxrbb5Bniz70mA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-swift": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.1.tgz",
-      "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw==",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.4.tgz",
+      "integrity": "sha512-CsFF0IFAbRtYNg0yZcdaYbADF5F3DsM8C4wHnZefQy8YcHP/qjAF/GdGfBFBLx+XSthYuBlo2b2XQVdz3cJZBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.1.tgz",
-      "integrity": "sha512-29lmUUnZgPh+ieZ5hunick8hzNIpNRtiJh9vAusNskPCrig3RTW6u7F+GG1a8uyslbzSw+Irjf40PTOan1OJJA==",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.5.tgz",
+      "integrity": "sha512-qH3epPB2d6d5w1l4hR2OsnN8qDQ4P0z6oDB7+YiNH+BoECXv4Z38MIV1H8cxIzD2wkzkt2JTcFYaVW72MDZAlg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.6.tgz",
-      "integrity": "sha512-1beC6O4P/j23VuxX+i0+F7XqPVc3hhiAzGJHEKqnWf5cWAXQtg0xz3xQJ5MvYx2a7iLaSa+lu7+05vG9UHyu9Q==",
-      "dev": true
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.9.tgz",
+      "integrity": "sha512-ZtO1/cVWvvR477ftTl2TFR09+IIzXG1rcin8CGYA0FO5WhyDAbn8v3A85QikS158BhTVUoq09lPYuSF9HBzqvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.0.tgz",
-      "integrity": "sha512-niiEMPWPV9IeRBRzZ0TBZmNnkK3olkOPYxC1Ny2AX4TGlYRajcW0WUtoSHmvvjZNfWLSg2L6ruiBeuPSbjnG6A==",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.3.tgz",
+      "integrity": "sha512-akmYbrgAGumqk1xXALtDJcEcOMYBYMnkjpmGzH13Ozhq1mkPF4VgllFQlm1xYde+BUKNnzMgPEzxrL2qZllgYA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.14.4.tgz",
-      "integrity": "sha512-GjKsBJvPXp4dYRqsMn7n1zpnKbnpfJnlKLOVeoFBh8fi4n06G50xYr+G25CWX1WT3WFaALAavvVICEUPrVsuqg==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.15.2.tgz",
+      "integrity": "sha512-37eYzVLqMv3KnY7UMmv/wC9OlUjPC7EJ3xMDourgDTNp6BtiPlMkHRTN5/yvRjukQedi41R1hewgCcZbwSpNXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
       },
@@ -1099,36 +1160,39 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.14.4.tgz",
-      "integrity": "sha512-qd68dD7xTA4Mnf/wjIKYz2SkiTBshIM+yszOUtLa06YJm0aocoNQ25FHXyYEQYm9NQXCYnRWWA02sFMGs8Sv/w==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.15.2.tgz",
+      "integrity": "sha512-x2ciWqi6y2RoTcXRTG3BuxAly1TIr4puLzKHkMWtnYp1A++gohCBczMt33FwrwFav0Dfx9M0mCpT1h1ORVwzhA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.14.4.tgz",
-      "integrity": "sha512-Uyfck64TfVU24wAP3BLGQ5EsAfzIZiLfN90NhttpEM7GlOBmbGrEJd4hNOwfpYsE/TT80eGWQVPRTLr5SDbXFA==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.15.2.tgz",
+      "integrity": "sha512-FMz3vgyPJjJsg0f78ToprOxR0lPhZOWwidxD+gOMLLfUzJ0mBC4VwoggrgIF6YEdXy/2UoIUtjh5B/Qfge9IDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.14.4.tgz",
-      "integrity": "sha512-htHhNF8WrM/NfaLSWuTYw0NqVgFRVHYSyHlRT3i/Yv5xvErld8Gw7C6ldm+0TLjoGlUe6X1VV72JSir7+yLp/Q==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.15.2.tgz",
+      "integrity": "sha512-AxS6nqh65V8BJf+ke7XNsDlieXfq/73XjZ4OxQAHvmML9kgXAbTviDcN6ddj6d2fTgU3EOSU1fBfDOqpS4n6Sg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.48.0.tgz",
-      "integrity": "sha512-G6QUWIcC+KvSwXNsJyDTHvqUdNoAVJPPgkc3+Uk4WBKqZvoXhlvazOgm9aL0HwihJLQf0l+tOE2UFzXBqCqgDw==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
+      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2446,19 +2510,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2554,7 +2605,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.5",
@@ -3080,6 +3132,7 @@
       "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
       "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^2.0.0",
         "resolve-from": "^5.0.0"
@@ -3270,6 +3323,7 @@
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
       "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -3344,7 +3398,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3437,30 +3492,30 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.14.4.tgz",
-      "integrity": "sha512-R5Awb3i/RKaVVcZzFt8dkN3M6VnifIEDYBcbzbmYjZ/Eq+ASF+QTmI0E9WPhMEcFM1nd7YOyXnETo560yRdoKw==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.15.2.tgz",
+      "integrity": "sha512-2XN6LeBAWyRLPUAcKrJTBftNc50VVVeU/j1GVU07hEun4Q4KZG9CbUT+YaZEnZo8xexVUBfZLtB5YxSImCnBtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.14.4",
-        "@cspell/cspell-pipe": "8.14.4",
-        "@cspell/cspell-types": "8.14.4",
-        "@cspell/dynamic-import": "8.14.4",
-        "@cspell/url": "8.14.4",
+        "@cspell/cspell-json-reporter": "8.15.2",
+        "@cspell/cspell-pipe": "8.15.2",
+        "@cspell/cspell-types": "8.15.2",
+        "@cspell/dynamic-import": "8.15.2",
+        "@cspell/url": "8.15.2",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.14.4",
-        "cspell-gitignore": "8.14.4",
-        "cspell-glob": "8.14.4",
-        "cspell-io": "8.14.4",
-        "cspell-lib": "8.14.4",
-        "fast-glob": "^3.3.2",
+        "cspell-dictionary": "8.15.2",
+        "cspell-gitignore": "8.15.2",
+        "cspell-glob": "8.15.2",
+        "cspell-io": "8.15.2",
+        "cspell-lib": "8.15.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
         "semver": "^7.6.3",
-        "strip-ansi": "^7.1.0"
+        "tinyglobby": "^0.2.9"
       },
       "bin": {
         "cspell": "bin.mjs",
@@ -3474,28 +3529,30 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.14.4.tgz",
-      "integrity": "sha512-cnUeJfniTiebqCaQmIUnbSrPrTH7xzKRQjJDHAEV0WYnOG2MhRXI13OzytdFdhkVBdStmgTzTCJKE7x+kmU2NA==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.15.2.tgz",
+      "integrity": "sha512-0vaZdp1gz5mt7RWTWStHHJBXfELtbtJNCl8RNz9E51906bhAyZ/yBvkOyjCW2Ofsdp2cKS11AuzTrq6N2lmK3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.14.4",
+        "@cspell/cspell-types": "8.15.2",
         "comment-json": "^4.2.5",
-        "yaml": "^2.5.1"
+        "yaml": "^2.6.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.14.4.tgz",
-      "integrity": "sha512-pZvQHxpAW5fZAnt3ZKKy3s7M+3CX2t8tCS3uJrpEHIynlCawpG0fPF78rVE5o+g0dON36Lguc/BUuSN4IWKLmQ==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.15.2.tgz",
+      "integrity": "sha512-Kvn8ZD+oQs2KKgGoC601NBju3xQcrP4bz1MVZ23ZN9fm6pukb0J8x9hP3d+AuQd/Cl2XG/y/hWZi6MT92uChIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.4",
-        "@cspell/cspell-types": "8.14.4",
-        "cspell-trie-lib": "8.14.4",
+        "@cspell/cspell-pipe": "8.15.2",
+        "@cspell/cspell-types": "8.15.2",
+        "cspell-trie-lib": "8.15.2",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -3503,14 +3560,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.14.4.tgz",
-      "integrity": "sha512-RwfQEW5hD7CpYwS7m3b0ONG0nTLKP6bL2tvMdl7qtaYkL7ztGdsBTtLD1pmwqUsCbiN5RuaOxhYOYeRcpFRIkQ==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.15.2.tgz",
+      "integrity": "sha512-XrQ3iouv2VvvpkL1ygEnOuqY/BGNt0tBZngFrb/Y12LWgcZ6unLZk4IaMYXlmjRZPtq7QuBe4dvG1D2SFcNEng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.14.4",
-        "cspell-glob": "8.14.4",
-        "cspell-io": "8.14.4",
+        "@cspell/url": "8.15.2",
+        "cspell-glob": "8.15.2",
+        "cspell-io": "8.15.2",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -3521,12 +3579,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.14.4.tgz",
-      "integrity": "sha512-C/xTS5nujMRMuguibq92qMVP767mtxrur7DcVolCvpzcivm1RB5NtIN0OctQxTyMbnmKeQv1t4epRKQ9A8vWRg==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.15.2.tgz",
+      "integrity": "sha512-AQNskPt3FOF1Z6mc+cvCZ33Xnb+a4cMVZwcLlApc/4uup6OvyEoXNN9IyeHVmloAUPlXadaA79balp3cMj2rWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.14.4",
+        "@cspell/url": "8.15.2",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -3534,13 +3593,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.14.4.tgz",
-      "integrity": "sha512-yaSKAAJDiamsw3FChbw4HXb2RvTQrDsLelh1+T4MavarOIcAxXrqAJ8ysqm++g+S/ooJz2YO8YWIyzJKxcMf8g==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.15.2.tgz",
+      "integrity": "sha512-yvCiOlg6G2l+lMWBSmWwnVqIVfDK/uUBzY4WIJQaXWtXRuJ9MdsSEQ3TFd9NgJUhY1gSF8O1zSqeCmfPNuS44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.4",
-        "@cspell/cspell-types": "8.14.4"
+        "@cspell/cspell-pipe": "8.15.2",
+        "@cspell/cspell-types": "8.15.2"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -3550,40 +3610,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.14.4.tgz",
-      "integrity": "sha512-o6OTWRyx/Az+PFhr1B0wMAwqG070hFC9g73Fkxd8+rHX0rfRS69QZH7LgSmZytqbZIMxCTDGdsLl33MFGWCbZQ==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.15.2.tgz",
+      "integrity": "sha512-Y4bEsKVXC48VawU+gU1lcsO7B55pNAjc8/C8Qg8UByobSOxtZKd7jaRRqqvd60Rh8lbgG4Nc05zKCb1CxY1+2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.14.4",
-        "@cspell/url": "8.14.4"
+        "@cspell/cspell-service-bus": "8.15.2",
+        "@cspell/url": "8.15.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.14.4.tgz",
-      "integrity": "sha512-qdkUkKtm+nmgpA4jQbmQTuepDfjHBDWvs3zDuEwVIVFq/h8gnXrRr75gJ3RYdTy+vOOqHPoLLqgxyqkUUrUGXA==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.15.2.tgz",
+      "integrity": "sha512-u4tO8NoLq/LuOdCBqJdKBLE51uCcE2Ni/DvaEFNfuhk2fCF3rE/2nCzLx6ZEAiFPHZVMs44MJxpH7VF8Rn/T8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.14.4",
-        "@cspell/cspell-pipe": "8.14.4",
-        "@cspell/cspell-resolver": "8.14.4",
-        "@cspell/cspell-types": "8.14.4",
-        "@cspell/dynamic-import": "8.14.4",
-        "@cspell/filetypes": "8.14.4",
-        "@cspell/strong-weak-map": "8.14.4",
-        "@cspell/url": "8.14.4",
+        "@cspell/cspell-bundled-dicts": "8.15.2",
+        "@cspell/cspell-pipe": "8.15.2",
+        "@cspell/cspell-resolver": "8.15.2",
+        "@cspell/cspell-types": "8.15.2",
+        "@cspell/dynamic-import": "8.15.2",
+        "@cspell/filetypes": "8.15.2",
+        "@cspell/strong-weak-map": "8.15.2",
+        "@cspell/url": "8.15.2",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.14.4",
-        "cspell-dictionary": "8.14.4",
-        "cspell-glob": "8.14.4",
-        "cspell-grammar": "8.14.4",
-        "cspell-io": "8.14.4",
-        "cspell-trie-lib": "8.14.4",
+        "cspell-config-lib": "8.15.2",
+        "cspell-dictionary": "8.15.2",
+        "cspell-glob": "8.15.2",
+        "cspell-grammar": "8.15.2",
+        "cspell-io": "8.15.2",
+        "cspell-trie-lib": "8.15.2",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -3598,13 +3660,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.14.4",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.14.4.tgz",
-      "integrity": "sha512-zu8EJ33CH+FA5lwTRGqS//Q6phO0qtgEmODMR1KPlD7WlrfTFMb3bWFsLo/tiv5hjpsn7CM6dYDAAgBOSkoyhQ==",
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.15.2.tgz",
+      "integrity": "sha512-dqEc4832iareVCA+pXuvdNwtUF+F8S+w15Tlv0fRdPTz8X4wcUtK0R5npYnL5dyuPhKBdO/PmKXGb7/5I0vBMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.4",
-        "@cspell/cspell-types": "8.14.4",
+        "@cspell/cspell-pipe": "8.15.2",
+        "@cspell/cspell-types": "8.15.2",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -3862,6 +3925,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4202,10 +4266,11 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
-      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4215,7 +4280,7 @@
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.9.0",
+        "eslint-module-utils": "^2.12.0",
         "hasown": "^2.0.2",
         "is-core-module": "^2.15.1",
         "is-glob": "^4.0.3",
@@ -4224,13 +4289,14 @@
         "object.groupby": "^1.0.3",
         "object.values": "^1.2.0",
         "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -4292,12 +4358,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.3.1.tgz",
-      "integrity": "sha512-SY9oUuTMr6aWoJggUS40LtMjsRzJPB5ZT7F432xZIHK3EfHF+8i48GbUBpwanrtlL9l1gILNTHK9o8gEhYLcKA==",
+      "version": "50.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.1.tgz",
+      "integrity": "sha512-OXIq+JJQPCLAKL473/esioFOwbXyRE5MAQ4HbZjcp3e+K3zdxt2uDpGs3FR+WezUXNStzEtTfgx15T+JFrVwBA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.48.0",
+        "@es-joy/jsdoccomment": "~0.49.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
         "debug": "^4.3.6",
@@ -4726,6 +4793,7 @@
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
       "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4880,6 +4948,7 @@
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
       "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4984,6 +5053,7 @@
       "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
       "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -5121,6 +5191,7 @@
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
       "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ini": "4.1.1"
       },
@@ -5237,6 +5308,7 @@
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5408,6 +5480,7 @@
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
       "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5447,6 +5520,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
       "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -8156,6 +8230,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
       "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.1.0"
       },
@@ -8575,6 +8650,7 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -9128,22 +9204,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -9254,6 +9314,48 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -9608,13 +9710,15 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walk-back": {
       "version": "5.1.1",
@@ -9810,6 +9914,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
       "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -9840,10 +9945,11 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -78,13 +78,13 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "cspell": "^8.14.4",
+    "cspell": "^8.15.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
-    "eslint-plugin-import": "^2.30.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.8.3",
-    "eslint-plugin-jsdoc": "^50.3.1",
+    "eslint-plugin-jsdoc": "^50.4.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps-dev): bump group with 3 updates
   * cspell from 8.14.4 to 8.15.2
   * eslint-plugin-import from 2.30.0 to 2.31.0
   * eslint-plugin-jsdoc from 50.3.1 to 50.4.1

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean

<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing