### PR TITLE
build(deps): bump group with 5 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,18 +17,18 @@
         "changelog": "bin/cli.js"
       },
       "devDependencies": {
-        "cspell": "^8.15.5",
+        "cspell": "^8.16.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^28.8.3",
-        "eslint-plugin-jsdoc": "^50.4.3",
+        "eslint-plugin-jest": "^28.9.0",
+        "eslint-plugin-jsdoc": "^50.5.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
-        "jsdoc-to-markdown": "^9.0.4",
-        "npm-check-updates": "^17.1.9",
+        "jsdoc-to-markdown": "^9.0.5",
+        "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3"
       },
@@ -645,17 +645,18 @@
       "license": "MIT"
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.15.5.tgz",
-      "integrity": "sha512-Su1gnTBbE7ouMQvM4DISUmP6sZiFyQRE+ODvjBzW+c/x9ZLbVp+2hBEEmxFSn5fdZCJzPOMwzwsjlLYykb9iUg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.16.0.tgz",
+      "integrity": "sha512-R0Eqq5kTZnmZ0elih5uY3TWjMqqAeMl7ciU7maUs+m1FNjCEdJXtJ9wrQxNgjmXi0tX8cvahZRO3O558tEz/KA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.0.5",
         "@cspell/dict-al": "^1.0.3",
         "@cspell/dict-aws": "^4.0.7",
         "@cspell/dict-bash": "^4.1.8",
         "@cspell/dict-companies": "^3.1.7",
-        "@cspell/dict-cpp": "^5.1.23",
+        "@cspell/dict-cpp": "^6.0.1",
         "@cspell/dict-cryptocurrencies": "^5.0.3",
         "@cspell/dict-csharp": "^4.0.5",
         "@cspell/dict-css": "^4.0.16",
@@ -688,8 +689,8 @@
         "@cspell/dict-makefile": "^1.0.3",
         "@cspell/dict-markdown": "^2.0.7",
         "@cspell/dict-monkeyc": "^1.0.9",
-        "@cspell/dict-node": "^5.0.4",
-        "@cspell/dict-npm": "^5.1.8",
+        "@cspell/dict-node": "^5.0.5",
+        "@cspell/dict-npm": "^5.1.11",
         "@cspell/dict-php": "^4.0.13",
         "@cspell/dict-powershell": "^5.0.13",
         "@cspell/dict-public-licenses": "^2.0.11",
@@ -698,11 +699,11 @@
         "@cspell/dict-ruby": "^5.0.7",
         "@cspell/dict-rust": "^4.0.9",
         "@cspell/dict-scala": "^5.0.6",
-        "@cspell/dict-software-terms": "^4.1.12",
+        "@cspell/dict-software-terms": "^4.1.13",
         "@cspell/dict-sql": "^2.1.8",
         "@cspell/dict-svelte": "^1.0.5",
         "@cspell/dict-swift": "^2.0.4",
-        "@cspell/dict-terraform": "^1.0.5",
+        "@cspell/dict-terraform": "^1.0.6",
         "@cspell/dict-typescript": "^3.1.11",
         "@cspell/dict-vue": "^3.0.3"
       },
@@ -711,31 +712,34 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.15.5.tgz",
-      "integrity": "sha512-yXd7KDBfUkA6y+MrOqK3q/UWorZgLIgyCZoFb0Pj67OU2ZMtgJ1VGFXAdzpKAEgEmdcblyoFzHkleYbg08qS6g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.16.0.tgz",
+      "integrity": "sha512-KLjPK94gA3JNuWy70LeenJ6EL3SFk2ejERKYJ6SVV/cVOKIvVd2qe42yX3/A/DkF2xzuZ2LD4z0sfoqQL1BaqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.15.5"
+        "@cspell/cspell-types": "8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.15.5.tgz",
-      "integrity": "sha512-X8QY73060hkR8040jabNJsvydeTG0owpqr9S0QJDdhG1z8uzenNcwR3hfwaIwQq5d6sIKcDFZY5qrO4x6eEAMw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.16.0.tgz",
+      "integrity": "sha512-WoCgrv/mrtwCY4lhc6vEcqN3AQ7lT6K0NW5ShoSo116U2tRaW0unApIYH4Va8u7T9g3wyspFEceQRR1xD9qb9w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.15.5.tgz",
-      "integrity": "sha512-ejzUGLEwI8TQWXovQzzvAgSNToRrQe3h97YrH2XaB9rZDKkeA7dIBZDQ/OgOfidO+ZAsPIOxdHai3CBzEHYX3A==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.16.0.tgz",
+      "integrity": "sha512-b+99bph43ptkXlQHgPXSkN/jK6LQHy2zL1Fm9up7+x6Yr64bxAzWzoeqJAPtnrPvFuOrFN0jZasZzKBw8CvrrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "global-directory": "^4.0.1"
       },
@@ -744,19 +748,21 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.15.5.tgz",
-      "integrity": "sha512-zZJRRvNhvUJntnw8sX4J5gE4uIHpX2oe+Tqs3lu2vRwogadNEXE4QNJbEQyQqgMePgmqULtRdxSBzG4wy4HoQg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.16.0.tgz",
+      "integrity": "sha512-+fn763JKA4EYCOv+1VShFq015UMEBAFRDr+rlCnesgLE0fv9TSFVLsjOfh9/g6GuGQLCRLUqKztwwuueeErstQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.15.5.tgz",
-      "integrity": "sha512-bMRq9slD/D0vXckxe9vubG02HXrV4cASo6Ytkaw8rTfxMKpkBgxJWjFWphCFLOCICD71q45fUSg+W5vCp83f/Q==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.16.0.tgz",
+      "integrity": "sha512-bGrIK7p4NVsK+QX/CYWmjax+FkzfSIZaIaoiBESGV5gmwgXDVRMJ3IP6tQVAmTtckOYHCmtT5CZgI8zXWr8dHQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -765,229 +771,267 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.5.tgz",
       "integrity": "sha512-6/RtZ/a+lhFVmrx/B7bfP7rzC4yjEYe8o74EybXcvu4Oue6J4Ey2WSYj96iuodloj1LWrkNCQyX5h4Pmcj0Iag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-al": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.0.3.tgz",
       "integrity": "sha512-V1HClwlfU/qwSq2Kt+MkqRAsonNu3mxjSCDyGRecdLGIHmh7yeEeaxqRiO/VZ4KP+eVSiSIlbwrb5YNFfxYZbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.7.tgz",
       "integrity": "sha512-PoaPpa2NXtSkhGIMIKhsJUXB6UbtTt6Ao3x9JdU9kn7fRZkwD4RjHDGqulucIOz7KeEX/dNRafap6oK9xHe4RA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-bash": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.8.tgz",
       "integrity": "sha512-I2CM2pTNthQwW069lKcrVxchJGMVQBzru2ygsHCwgidXRnJL/NTjAPOFTxN58Jc1bf7THWghfEDyKX/oyfc0yg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-companies": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.7.tgz",
       "integrity": "sha512-ncVs/efuAkP1/tLDhWbXukBjgZ5xOUfe03neHMWsE8zvXXc5+Lw6TX5jaJXZLOoES/f4j4AhRE20jsPCF5pm+A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.23.tgz",
-      "integrity": "sha512-59VUam6bYWzn50j8FASWWLww0rBPA0PZfjMZBvvt0aqMpkvXzoJPnAAI4eDDSibPWVHKutjpqLmast+uMLHVsQ==",
-      "dev": true
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.2.tgz",
+      "integrity": "sha512-yw5eejWvY4bAnc6LUA44m4WsFwlmgPt2uMSnO7QViGMBDuoeopMma4z9XYvs4lSjTi8fIJs/A1YDfM9AVzb8eg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.3.tgz",
       "integrity": "sha512-bl5q+Mk+T3xOZ12+FG37dB30GDxStza49Rmoax95n37MTLksk9wBo1ICOlPJ6PnDUSyeuv4SIVKgRKMKkJJglA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-csharp": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.5.tgz",
       "integrity": "sha512-c/sFnNgtRwRJxtC3JHKkyOm+U3/sUrltFeNwml9VsxKBHVmvlg4tk4ar58PdpW9/zTlGUkWi2i85//DN1EsUCA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.16.tgz",
       "integrity": "sha512-70qu7L9z/JR6QLyJPk38fNTKitlIHnfunx0wjpWQUQ8/jGADIhMCrz6hInBjqPNdtGpYm8d1dNFyF8taEkOgrQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.2.4.tgz",
       "integrity": "sha512-of/cVuUIZZK/+iqefGln8G3bVpfyN6ZtH+LyLkHMoR5tEj+2vtilGNk9ngwyR8L4lEqbKuzSkOxgfVjsXf5PsQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-data-science": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.5.tgz",
       "integrity": "sha512-nNSILXmhSJox9/QoXICPQgm8q5PbiSQP4afpbkBqPi/u/b3K9MbNH5HvOOa6230gxcGdbZ9Argl2hY/U8siBlg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-django": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.3.tgz",
       "integrity": "sha512-yBspeL3roJlO0a1vKKNaWABURuHdHZ9b1L8d3AukX0AsBy9snSggc8xCavPmSzNfeMDXbH+1lgQiYBd3IW03fg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-docker": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.11.tgz",
       "integrity": "sha512-s0Yhb16/R+UT1y727ekbR/itWQF3Qz275DR1ahOa66wYtPjHUXmhM3B/LT3aPaX+hD6AWmK23v57SuyfYHUjsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.8.tgz",
       "integrity": "sha512-MD8CmMgMEdJAIPl2Py3iqrx3B708MbCIXAuOeZ0Mzzb8YmLmiisY7QEYSZPg08D7xuwARycP0Ki+bb0GAkFSqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-elixir": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.6.tgz",
       "integrity": "sha512-TfqSTxMHZ2jhiqnXlVKM0bUADtCvwKQv2XZL/DI0rx3doG8mEMS8SGPOmiyyGkHpR/pGOq18AFH3BEm4lViHIw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.26.tgz",
-      "integrity": "sha512-hDbHYJsi3UgU1J++B0WLiYhWQdsmve3CH53FIaMRAdhrWOHcuw7h1dYkQXHFEP5lOjaq53KUHp/oh5su6VkIZg==",
-      "dev": true
+      "version": "4.3.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.27.tgz",
+      "integrity": "sha512-7JYHahRWpi0VykWFTSM03KL/0fs6YtYfpOaTAg4N/d0wB2GfwVG/FJ/SBCjD4LBc6Rx9dzdo95Hs4BB8GPQbOA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.7.tgz",
       "integrity": "sha512-qNFo3G4wyabcwnM+hDrMYKN9vNVg/k9QkhqSlSst6pULjdvPyPs1mqz1689xO/v9t8e6sR4IKc3CgUXDMTYOpA==",
-      "dev": true
+      "dev": true,
+      "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
       "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.8.tgz",
       "integrity": "sha512-D3N8sm/iptzfVwsib/jvpX+K/++rM8SRpLDFUaM4jxm8EyGmSIYRbKZvdIv5BkAWmMlTWoRqlLn7Yb1b11jKJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-flutter": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.3.tgz",
       "integrity": "sha512-52C9aUEU22ptpgYh6gQyIdA4MP6NPwzbEqndfgPh3Sra191/kgs7CVqXiO1qbtZa9gnYHUoVApkoxRE7mrXHfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fonts": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.3.tgz",
       "integrity": "sha512-sPd17kV5qgYXLteuHFPn5mbp/oCHKgitNfsZLFC3W2fWEgZlhg4hK+UGig3KzrYhhvQ8wBnmZrAQm0TFKCKzsA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fsharp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.4.tgz",
       "integrity": "sha512-G5wk0o1qyHUNi9nVgdE1h5wl5ylq7pcBjX8vhjHcO4XBq20D5eMoXjwqMo/+szKAqzJ+WV3BgAL50akLKrT9Rw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.3.tgz",
       "integrity": "sha512-62PbndIyQPH11mAv0PyiyT0vbwD0AXEocPpHlCHzfb5v9SspzCCbzQ/LIBiFmyRa+q5LMW35CnSVu6OXdT+LKg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-gaming-terms": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.8.tgz",
       "integrity": "sha512-7OL0zTl93WFWhhtpXFrtm9uZXItC3ncAs8d0iQDMMFVNU1rBr6raBNxJskxE5wx2Ant12fgI66ZGVagXfN+yfA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-git": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.3.tgz",
       "integrity": "sha512-LSxB+psZ0qoj83GkyjeEH/ZViyVsGEF/A6BAo8Nqc0w0HjD2qX/QR4sfA6JHUgQ3Yi/ccxdK7xNIo67L2ScW5A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.16.tgz",
-      "integrity": "sha512-hZOBlgcguv2Hdc93n2zjdAQm1j3grsN9T9WhPnQ1wh2vUDoCLEujg+6gWhjcLb8ECOcwZTWgNyQLWeOxEsAj/w==",
-      "dev": true
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.17.tgz",
+      "integrity": "sha512-uDDLEJ/cHdLiqPw4+5BnmIo2i/TSR+uDvYd6JlBjTmjBKpOCyvUgYRztH7nv5e7virsN5WDiUWah4/ATQGz4Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-google": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.4.tgz",
       "integrity": "sha512-JThUT9eiguCja1mHHLwYESgxkhk17Gv7P3b1S7ZJzXw86QyVHPrbpVoMpozHk0C9o+Ym764B7gZGKmw9uMGduQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-haskell": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.4.tgz",
       "integrity": "sha512-EwQsedEEnND/vY6tqRfg9y7tsnZdxNqOxLXSXTsFA6JRhUlr8Qs88iUUAfsUzWc4nNmmzQH2UbtT25ooG9x4nA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.10.tgz",
       "integrity": "sha512-I9uRAcdtHbh0wEtYZlgF0TTcgH0xaw1B54G2CW+tx4vHUwlde/+JBOfIzird4+WcMv4smZOfw+qHf7puFUbI5g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.3.tgz",
       "integrity": "sha512-aABXX7dMLNFdSE8aY844X4+hvfK7977sOWgZXo4MTGAmOzR8524fjbJPswIBK7GaD3+SgFZ2yP2o0CFvXDGF+A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.10.tgz",
       "integrity": "sha512-pVNcOnmoGiNL8GSVq4WbX/Vs2FGS0Nej+1aEeGuUY9CU14X8yAVCG+oih5ZoLt1jaR8YfR8byUF8wdp4qG4XIw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-julia": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.4.tgz",
       "integrity": "sha512-bFVgNX35MD3kZRbXbJVzdnN7OuEqmQXGpdOi9jzB40TSgBTlJWA4nxeAKV4CPCZxNRUGnLH0p05T/AD7Aom9/w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-k8s": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.9.tgz",
       "integrity": "sha512-Q7GELSQIzo+BERl2ya/nBEnZeQC+zJP19SN1pI6gqDYraM51uYJacbbcWLYYO2Y+5joDjNt/sd/lJtLaQwoSlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-latex": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.3.tgz",
       "integrity": "sha512-2KXBt9fSpymYHxHfvhUpjUFyzrmN4c4P8mwIzweLyvqntBT3k0YGZJSriOdjfUjwSygrfEwiuPI1EMrvgrOMJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lorem-ipsum": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.3.tgz",
       "integrity": "sha512-WFpDi/PDYHXft6p0eCXuYnn7mzMEQLVeqpO+wHSUd+kz5ADusZ4cpslAA4wUZJstF1/1kMCQCZM6HLZic9bT8A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-lua": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.6.tgz",
       "integrity": "sha512-Jwvh1jmAd9b+SP9e1GkS2ACbqKKRo9E1f9GdjF/ijmooZuHU0hPyqvnhZzUAxO1egbnNjxS/J2T6iUtjAUK2KQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-makefile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.3.tgz",
       "integrity": "sha512-R3U0DSpvTs6qdqfyBATnePj9Q/pypkje0Nj26mQJ8TOBQutCRAJbr2ZFAeDjgRx5EAJU/+8txiyVF97fbVRViw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-markdown": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.7.tgz",
       "integrity": "sha512-F9SGsSOokFn976DV4u/1eL4FtKQDSgJHSZ3+haPRU5ki6OEqojxKa8hhj4AUrtNFpmBaJx/WJ4YaEzWqG7hgqg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "@cspell/dict-css": "^4.0.16",
         "@cspell/dict-html": "^4.0.10",
@@ -999,43 +1043,50 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.9.tgz",
       "integrity": "sha512-Jvf6g5xlB4+za3ThvenYKREXTEgzx5gMUSzrAxIiPleVG4hmRb/GBSoSjtkGaibN3XxGx5x809gSTYCA/IHCpA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.4.tgz",
-      "integrity": "sha512-Hz5hiuOvZTd7Cp1IBqUZ7/ChwJeQpD5BJuwCaDn4mPNq4iMcQ1iWBYMThvNVqCEDgKv63X52nT8RAWacss98qg==",
-      "dev": true
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.5.tgz",
+      "integrity": "sha512-7NbCS2E8ZZRZwlLrh2sA0vAk9n1kcTUiRp/Nia8YvKaItGXLfxYqD2rMQ3HpB1kEutal6hQLVic3N2Yi1X7AaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.8.tgz",
-      "integrity": "sha512-AJELYXeB4fQdIoNfmuaQxB1Hli3cX6XPsQCjfBxlu0QYXhrjB/IrCLLQAjWIywDqJiWyGUFTz4DqaANm8C/r9Q==",
-      "dev": true
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.13.tgz",
+      "integrity": "sha512-7S1Pwq16M4sqvv/op7iHErc6Diz+DXsBYRMS0dDj6HUS44VXMvgejXa3RMd5jwBmcHzkInFm3DW1eb2exBs0cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.13.tgz",
       "integrity": "sha512-P6sREMZkhElzz/HhXAjahnICYIqB/HSGp1EhZh+Y6IhvC15AzgtDP8B8VYCIsQof6rPF1SQrFwunxOv8H1e2eg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-powershell": {
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.13.tgz",
       "integrity": "sha512-0qdj0XZIPmb77nRTynKidRJKTU0Fl+10jyLbAhFTuBWKMypVY06EaYFnwhsgsws/7nNX8MTEQuewbl9bWFAbsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-public-licenses": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.11.tgz",
       "integrity": "sha512-rR5KjRUSnVKdfs5G+gJ4oIvQvm8+NJ6cHWY2N+GE69/FSGWDOPHxulCzeGnQU/c6WWZMSimG9o49i9r//lUQyA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.12.tgz",
       "integrity": "sha512-U25eOFu+RE0aEcF2AsxZmq3Lic7y9zspJ9SzjrC0mfJz+yr3YmSCw4E0blMD3mZoNcf7H/vMshuKIY5AY36U+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspell/dict-data-science": "^2.0.5"
       }
@@ -1044,73 +1095,85 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.4.tgz",
       "integrity": "sha512-cBpRsE/U0d9BRhiNRMLMH1PpWgw+N+1A2jumgt1if9nBGmQw4MUpg2u9I0xlFVhstTIdzXiLXMxP45cABuiUeQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.7.tgz",
       "integrity": "sha512-4/d0hcoPzi5Alk0FmcyqlzFW9lQnZh9j07MJzPcyVO62nYJJAGKaPZL2o4qHeCS/od/ctJC5AHRdoUm0ktsw6Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.9.tgz",
-      "integrity": "sha512-Dhr6TIZsMV92xcikKIWei6p/qswS4M+gTkivpWwz4/1oaVk2nRrxJmCdRoVkJlZkkAc17rjxrS12mpnJZI0iWw==",
-      "dev": true
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.10.tgz",
+      "integrity": "sha512-6o5C8566VGTTctgcwfF3Iy7314W0oMlFFSQOadQ0OEdJ9Z9ERX/PDimrzP3LGuOrvhtEFoK8pj+BLnunNwRNrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-scala": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.6.tgz",
       "integrity": "sha512-tl0YWAfjUVb4LyyE4JIMVE8DlLzb1ecHRmIWc4eT6nkyDqQgHKzdHsnusxFEFMVLIQomgSg0Zz6hJ5S1E4W4ww==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.12.tgz",
-      "integrity": "sha512-MHDAK/WlEdMJiDQ6lJ3SF7VogdfJcRXGYWfO4v90rxW8HDVfKDXVk3zpJhjoZGq56ujR1qmeYkQsM6MlB69uJA==",
-      "dev": true
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.17.tgz",
+      "integrity": "sha512-QORIk1R5DV8oOQ+oAlUWE7UomaJwUucqu2srrc2+PmkoI6R1fJwwg2uHCPBWlIb4PGDNEdXLv9BAD13H+0wytQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-sql": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.8.tgz",
       "integrity": "sha512-dJRE4JV1qmXTbbGm6WIcg1knmR6K5RXnQxF4XHs5HA3LAjc/zf77F95i5LC+guOGppVF6Hdl66S2UyxT+SAF3A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-svelte": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.5.tgz",
       "integrity": "sha512-sseHlcXOqWE4Ner9sg8KsjxwSJ2yssoJNqFHR9liWVbDV+m7kBiUtn2EB690TihzVsEmDr/0Yxrbb5Bniz70mA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-swift": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.4.tgz",
       "integrity": "sha512-CsFF0IFAbRtYNg0yZcdaYbADF5F3DsM8C4wHnZefQy8YcHP/qjAF/GdGfBFBLx+XSthYuBlo2b2XQVdz3cJZBw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.5.tgz",
-      "integrity": "sha512-qH3epPB2d6d5w1l4hR2OsnN8qDQ4P0z6oDB7+YiNH+BoECXv4Z38MIV1H8cxIzD2wkzkt2JTcFYaVW72MDZAlg==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.6.tgz",
+      "integrity": "sha512-Sqm5vGbXuI9hCFcr4w6xWf4Y25J9SdleE/IqfM6RySPnk8lISEmVdax4k6+Kinv9qaxyvnIbUUN4WFLWcBPQAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-typescript": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.11.tgz",
       "integrity": "sha512-FwvK5sKbwrVpdw0e9+1lVTl8FPoHYvfHRuQRQz2Ql5XkC0gwPPkpoyD1zYImjIyZRoYXk3yp9j8ss4iz7A7zoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.3.tgz",
       "integrity": "sha512-akmYbrgAGumqk1xXALtDJcEcOMYBYMnkjpmGzH13Ozhq1mkPF4VgllFQlm1xYde+BUKNnzMgPEzxrL2qZllgYA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.15.5.tgz",
-      "integrity": "sha512-xfLRVi8zHKCGK1fg1ixXQ0bAlIU9sGm7xfbTmGG8TQt+iaKHVMIlt+XeCAo0eE7aKjIaIfqcC/PCIdUJiODuGA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.16.0.tgz",
+      "integrity": "sha512-FH+B5y71qfunagXiLSJhXP9h/Vwb1Z8Cc/hLmliGekw/Y8BuYknL86tMg9grXBYNmM0kifIv6ZesQl8Km/p/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
       },
@@ -1119,28 +1182,31 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.15.5.tgz",
-      "integrity": "sha512-ljEFUp61mw5RWZ3S6ke6rvGKy8m4lZZjRd5KO07RYyGwSeLa4PX9AyTgSzuqXiN9y1BwogD3xolCMfPsMrtZIQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.16.0.tgz",
+      "integrity": "sha512-u2Ub0uSwXFPJFvXhAO/0FZBj3sMr4CeYCiQwTUsdFRkRMFpbTc7Vf+a+aC2vIj6WcaWrYXrJy3NZF/yjqF6SGw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.15.5.tgz",
-      "integrity": "sha512-7VzDAXsJPDXllTIi9mvQwd7PR43TPk1Ix3ocLTZDVNssf1cQbmLiQX6YWk0k8FWGfIPoIMlByw4tTSizRJcTcw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.16.0.tgz",
+      "integrity": "sha512-R6N12wEIQpBk2uyni/FU1SFSIjP0uql7ynXVcF1ob8/JJeRoikssydi9Xq5J6ghMw+X50u35mFvg9BgWKz0d+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.15.5.tgz",
-      "integrity": "sha512-z8q7LUppFiNvytX2qrKDkXcsmOrwjqFf/5RkcpNppDezLrFejaMZu4BEVNcPrFCeS2J04K+uksNL1LYSob8jCg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.16.0.tgz",
+      "integrity": "sha512-zW+6hAieD/FjysfjY4mVv7iHWWasBP3ldj6L+xy2p4Kuax1nug7uuJqMHlAVude/OywNwENG0rYaP/P9Pg4O+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0"
       }
@@ -2026,6 +2092,7 @@
       "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
       "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -2210,13 +2277,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2226,7 +2295,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.5.1",
@@ -2561,7 +2631,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.5",
@@ -2851,7 +2922,8 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3013,6 +3085,7 @@
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
       "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -3087,6 +3160,7 @@
       "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
       "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^2.0.0",
         "resolve-from": "^5.0.0"
@@ -3169,18 +3243,27 @@
       "license": "MIT"
     },
     "node_modules/command-line-args": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.0.tgz",
-      "integrity": "sha512-zDdHxHzlCp/gA1gy0VtPK3YL0Aob3ijJdwZ7H3HSl55hh8EziLtRlyj/od8EGRJfX8IjussC/mQkScl2Ms5Suw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
-        "find-replace": "^5.0.1",
+        "find-replace": "^5.0.2",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^7.1.1"
+        "typical": "^7.2.0"
       },
       "engines": {
         "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/command-line-usage": {
@@ -3277,6 +3360,7 @@
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
       "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -3351,7 +3435,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3444,24 +3529,25 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.15.5.tgz",
-      "integrity": "sha512-Vp1WI6axghVvenZS7GUlsZf6JFF7jDXdV5f4nXWjrZLbTrH+wbnFEO2mg+QJWa4IN35igjNYeu9TbA9/EGJzog==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.16.0.tgz",
+      "integrity": "sha512-U6Up/4nODE+Ca+zqwZXTgBioGuF2JQHLEUIuoRJkJzAZkIBYDqrMXM+zdSL9E39+xb9jAtr9kPAYJf1Eybgi9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.15.5",
-        "@cspell/cspell-pipe": "8.15.5",
-        "@cspell/cspell-types": "8.15.5",
-        "@cspell/dynamic-import": "8.15.5",
-        "@cspell/url": "8.15.5",
+        "@cspell/cspell-json-reporter": "8.16.0",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "@cspell/dynamic-import": "8.16.0",
+        "@cspell/url": "8.16.0",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.15.5",
-        "cspell-gitignore": "8.15.5",
-        "cspell-glob": "8.15.5",
-        "cspell-io": "8.15.5",
-        "cspell-lib": "8.15.5",
+        "cspell-dictionary": "8.16.0",
+        "cspell-gitignore": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-io": "8.16.0",
+        "cspell-lib": "8.16.0",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
@@ -3480,12 +3566,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.15.5.tgz",
-      "integrity": "sha512-16XBjAlUWO46uEuUKHQvSeiU7hQzG9Pqg6lwKQOyZ/rVLZyihk7JGtnWuG83BbW0RFokB/BcgT1q6OegWJiEZw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.16.0.tgz",
+      "integrity": "sha512-PGT6ohLtIYXYLIm+R5hTcTrF0dzj8e7WAUJSJe5WlV/7lrwVdwgWaliLcXtSSPmfxgczr6sndX9TMJ2IEmPrmg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.15.5",
+        "@cspell/cspell-types": "8.16.0",
         "comment-json": "^4.2.5",
         "yaml": "^2.6.0"
       },
@@ -3494,14 +3581,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.15.5.tgz",
-      "integrity": "sha512-L+4MD3KItFGsxR8eY2ed6InsD7hZU1TIAeV2V4sG0wIbUXJXbPFxBTNZJrPLxTzAeCutHmkZwAl4ZCGu18bgtw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.16.0.tgz",
+      "integrity": "sha512-Y3sN6ttLBKbu0dOLcduY641n5QP1srUvZkW4bOTnG455DbIZfilrP1El/2Hl0RS6hC8LN9PM4bsIm/2xgdbApA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.5",
-        "@cspell/cspell-types": "8.15.5",
-        "cspell-trie-lib": "8.15.5",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "cspell-trie-lib": "8.16.0",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -3509,14 +3597,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.15.5.tgz",
-      "integrity": "sha512-z5T0Xswfiu2NbkoVdf6uwEWzOgxCBb3L8kwB6lxzK5iyQDW2Bqlk+5b6KQaY38OtjTjJ9zzIJfFN3MfFlMFd3A==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.16.0.tgz",
+      "integrity": "sha512-ODKe0ooyzYSBJkwgIVZSRIvzoZfT4tEbFt4fFDT88wPyyfX7xp7MAQhXy5KD1ocXH0WvYbdv37qzn2UbckrahA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.15.5",
-        "cspell-glob": "8.15.5",
-        "cspell-io": "8.15.5",
+        "@cspell/url": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-io": "8.16.0",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -3527,12 +3616,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.15.5.tgz",
-      "integrity": "sha512-VpfP16bRbkHEyGGjf6/EifFxETfS7lpcHbYt1tRi6VhCv1FTMqbB7H7Aw+DQkDezOUN8xdw0gYe/fk5AJGOBDg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.16.0.tgz",
+      "integrity": "sha512-xJSXRHwfENCNFmjpVSEucXY8E3BrpSCA+TukmOYtLyaMKtn6EAwoCpEU7Oj2tZOjdivprPmQ74k4Dqb1RHjIVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.15.5",
+        "@cspell/url": "8.16.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -3540,13 +3630,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.15.5.tgz",
-      "integrity": "sha512-2YnlSATtWHNL6cgx1qmTsY5ZO0zu8VdEmfcLQKgHr67T7atLRUnWAlmh06WMLd5qqp8PpWNPaOJF2prEYAXsUA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.16.0.tgz",
+      "integrity": "sha512-vvbJEkBqXocGH/H975RtkfMzVpNxNGMd0JCDd+NjbpeRyZceuChFw5Tie7kHteFY29SwZovub+Am3F4H1kmf9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.5",
-        "@cspell/cspell-types": "8.15.5"
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -3556,40 +3647,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.15.5.tgz",
-      "integrity": "sha512-6kBK+EGTG9hiUDfB55r3xbhc7YUA5vJTXoc65pe9PXd4vgXXfrPRuy+5VRtvgSMoQj59oWOQw3ZqTAR95gbGnw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.16.0.tgz",
+      "integrity": "sha512-WIK5uhPMjGsTAzm2/fGRbIdr7zWsMVG1fn8wNJYUiYELuyvzvLelfI1VG6szaFCGYqd6Uvgb/fS0uNbwGqCLAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.15.5",
-        "@cspell/url": "8.15.5"
+        "@cspell/cspell-service-bus": "8.16.0",
+        "@cspell/url": "8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.15.5.tgz",
-      "integrity": "sha512-DGieMWc82ouHb6Rq2LRKAlG4ExeQL1D5uvemgaouVHMZq4GvPtVaTwA6qHhw772/5z665oOVsRCicYbDtP4V3w==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.16.0.tgz",
+      "integrity": "sha512-fU8CfECyuhT12COIi4ViQu2bTkdqaa+05YSd2ZV8k8NA7lapPaMFnlooxdfcwwgZJfHeMhRVMzvQF1OhWmwGfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.15.5",
-        "@cspell/cspell-pipe": "8.15.5",
-        "@cspell/cspell-resolver": "8.15.5",
-        "@cspell/cspell-types": "8.15.5",
-        "@cspell/dynamic-import": "8.15.5",
-        "@cspell/filetypes": "8.15.5",
-        "@cspell/strong-weak-map": "8.15.5",
-        "@cspell/url": "8.15.5",
+        "@cspell/cspell-bundled-dicts": "8.16.0",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-resolver": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "@cspell/dynamic-import": "8.16.0",
+        "@cspell/filetypes": "8.16.0",
+        "@cspell/strong-weak-map": "8.16.0",
+        "@cspell/url": "8.16.0",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.15.5",
-        "cspell-dictionary": "8.15.5",
-        "cspell-glob": "8.15.5",
-        "cspell-grammar": "8.15.5",
-        "cspell-io": "8.15.5",
-        "cspell-trie-lib": "8.15.5",
+        "cspell-config-lib": "8.16.0",
+        "cspell-dictionary": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-grammar": "8.16.0",
+        "cspell-io": "8.16.0",
+        "cspell-trie-lib": "8.16.0",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -3604,13 +3697,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.15.5.tgz",
-      "integrity": "sha512-DAEkp51aFgpp9DFuJkNki0kVm2SVR1Hp0hD3Pnta7S4X2h5424TpTVVPltAIWtcdxRLGbX6N2x26lTI4K/YfpQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.16.0.tgz",
+      "integrity": "sha512-Io1qqI0r4U9ewAWBLClFBBlxLeAoIi15PUGJi4Za1xrlgQJwRE8PMNIJNHKmPEIp78Iute3o/JyC2OfWlxl4Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.5",
-        "@cspell/cspell-types": "8.15.5",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -3622,6 +3716,7 @@
       "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.2.tgz",
       "integrity": "sha512-H4s4arcLx/ugbu1XkkgSvcUZax0L6tXUqnppGniQb8l5VjUKGHoayXE5RiriiPhYDd+kjZnaok1Uig13PKtKYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
@@ -3856,6 +3951,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -3868,6 +3964,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4275,10 +4372,11 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.8.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
-      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+      "version": "28.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
+      "integrity": "sha512-rLu1s1Wf96TgUUxSw6loVIkNtUjq1Re7A9QdCCHSohnvXEBAjuL420h0T/fMmkQlNsQP2GhQzEUpYHPfxBkvYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -4300,10 +4398,11 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.3.tgz",
-      "integrity": "sha512-uWtwFxGRv6B8sU63HZM5dAGDhgsatb+LONwmILZJhdRALLOkCX2HFZhdL/Kw2ls8SQMAVEfK+LmnEfxInRN8HA==",
+      "version": "50.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.5.0.tgz",
+      "integrity": "sha512-xTkshfZrUbiSHXBwZ/9d5ulZ2OcHXxSvm/NPo494H/hadLRJwOq5PMV0EUpMqsb9V+kQo+9BAgi6Z7aJtdBp2A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.49.0",
         "are-docs-informative": "^0.0.2",
@@ -4734,6 +4833,7 @@
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
       "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4888,6 +4988,7 @@
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
       "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4992,6 +5093,7 @@
       "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
       "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -5129,6 +5231,7 @@
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
       "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ini": "4.1.1"
       },
@@ -5245,6 +5348,7 @@
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5416,6 +5520,7 @@
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
       "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5455,6 +5560,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
       "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -7222,6 +7328,7 @@
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
       "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "xmlcreate": "^2.0.4"
       }
@@ -7231,6 +7338,7 @@
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
       "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
@@ -7256,10 +7364,11 @@
       }
     },
     "node_modules/jsdoc-api": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.3.tgz",
-      "integrity": "sha512-DSMq0K/pSuzBEwE+w7f2ZXNnkBAJoL+ytfMr6Cl0CV5CDk0fy4jb2BAdkPFZqJlmtdIVNWpeb8cPj5+S4rp9Qw==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.4.tgz",
+      "integrity": "sha512-di8lggLACEttpyAZ6WjKKafUP4wC4prAGjt40nMl7quDpp2nD7GmLt6/WxhRu9Q6IYoAAySsNeidBXYVAMwlqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
         "cache-point": "^3.0.0",
@@ -7297,17 +7406,18 @@
       }
     },
     "node_modules/jsdoc-to-markdown": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.0.4.tgz",
-      "integrity": "sha512-kPlZ0Zw8l05LBS3kYNExwlUTOv2e38zuRnMgEbyOt15YSFrQuAPS7hnJbqmh//OCfy3wSaj2Gjy08bkrzic7xw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.0.5.tgz",
+      "integrity": "sha512-lqvKgSva+wGUusRz6xtImdM92lrjHNmyi7LyWdLMQBijCnoFwTZjNF3zUqm6uahsSaRALQNyzGXmjaef6IUE4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
-        "command-line-args": "^6.0.0",
+        "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
         "config-master": "^3.1.0",
         "dmd": "^7.0.7",
-        "jsdoc-api": "^9.3.3",
+        "jsdoc-api": "^9.3.4",
         "jsdoc-parse": "^6.2.4",
         "walk-back": "^5.1.1"
       },
@@ -7341,6 +7451,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7421,6 +7532,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -7471,6 +7583,7 @@
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -7535,13 +7648,15 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7597,6 +7712,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -7614,6 +7730,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
       "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
       "dev": true,
+      "license": "Unlicense",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
@@ -7635,7 +7752,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -7715,6 +7833,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -7797,10 +7916,11 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.9",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.9.tgz",
-      "integrity": "sha512-Gfv5S8NNJKTilM1gesFNYka6bUaBs5LnVyPjApXPQphHijrlLFDMw1uSmwYMZbvJSkLZSOx03e8CHcG0Td5SMA==",
+      "version": "17.1.11",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.11.tgz",
+      "integrity": "sha512-TR2RuGIH7P3Qrb0jfdC/nT7JWqXPKjDlxuNQt3kx4oNVf1Pn5SBRB7KLypgYZhruivJthgTtfkkyK4mz342VjA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
         "npm-check-updates": "build/cli.js"
@@ -7998,6 +8118,7 @@
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz",
       "integrity": "sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8164,6 +8285,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
       "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.1.0"
       },
@@ -8482,6 +8604,7 @@
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8583,6 +8706,7 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -8601,6 +8725,7 @@
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
       "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -9513,7 +9638,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -9548,7 +9674,8 @@
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
@@ -9639,13 +9766,15 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walk-back": {
       "version": "5.1.1",
@@ -9841,6 +9970,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
       "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -9852,7 +9982,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -9871,10 +10002,11 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -78,18 +78,18 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "cspell": "^8.15.5",
+    "cspell": "^8.16.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-jest": "^28.8.3",
-    "eslint-plugin-jsdoc": "^50.4.3",
+    "eslint-plugin-jest": "^28.9.0",
+    "eslint-plugin-jsdoc": "^50.5.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
-    "jsdoc-to-markdown": "^9.0.4",
-    "npm-check-updates": "^17.1.9",
+    "jsdoc-to-markdown": "^9.0.5",
+    "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3"
   }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump group with 5 updates
   * cspell from 8.15.5 to 8.16.0
   * eslint-plugin-jest from 28.8.3 to 28.9.0
   * eslint-plugin-jsdoc from 50.4.3 to 50.5.0
   * jsdoc-to-markdown from 9.0.4 to 9.0.5
   * npm-check-updates from 17.1.9 to 17.1.11

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean

<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing