### PR TITLE
feat(cli): remote domain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ NPM install...
                                                [array] [default: "chore(release)"]
         --release-desc     Add a description under the release version header
                            copy. Example, "Lorem ipsum dolor sit!"        [string]
+        --remote-domain    The remote HTTPS and SSH domain used to connect local
+                           repos to remotes. Defaults to Github.
+                                                  [string] [default: "github.com"]
     -h, --help             Show help                                     [boolean]
     -v, --version          Show version number                           [boolean]
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,6 +25,7 @@ const {
   'pr-path': prPath,
   'release-message': releaseTypeScope,
   'release-desc': releaseDescription,
+  'remote-domain': remoteDomain,
   'link-url': linkUrl
 } = yargs
   .usage('Generate a CHANGELOG.md with conventional commit types.\n\nUsage: changelog [options]')
@@ -123,6 +124,11 @@ const {
   .option('release-desc', {
     describe: 'Add a description under the release version header copy. Example, "Lorem ipsum dolor sit!"',
     type: 'string'
+  })
+  .option('remote-domain', {
+    default: 'github.com',
+    describe: 'The remote HTTPS and SSH domain used to connect local repos to remotes. Defaults to Github.',
+    type: 'string'
   }).argv;
 
 /**
@@ -167,7 +173,8 @@ OPTIONS._set = {
   prPath,
   releaseBranch,
   releaseDescription,
-  releaseTypeScope
+  releaseTypeScope,
+  remoteDomain
 };
 
 /**

--- a/src/README.md
+++ b/src/README.md
@@ -190,6 +190,9 @@ It handles formatting and ensures all URLs end with a trailing slash.
     </tr><tr>
     <td>options.prPath</td><td><code>string</code></td><td></td><td><p>Path segment for pull request URLs (e.g., &quot;pull&quot;)</p>
 </td>
+    </tr><tr>
+    <td>options.remoteDomain</td><td><code>string</code></td><td></td><td><p>Available remote domain for parsing if linkUrl is not provided.</p>
+</td>
     </tr>  </tbody>
 </table>
 
@@ -437,6 +440,7 @@ modifying the file.
     * [~generalCommitType](#module_Global..generalCommitType) : <code>object</code>
     * [~conventionalCommitType](#module_Global..conventionalCommitType) : <code>object</code>
     * [~OPTIONS](#module_Global..OPTIONS) : <code>object</code>
+    * [~isUrl(str, [settings])](#module_Global..isUrl) ⇒ <code>boolean</code>
 
 <a name="module_Global..color"></a>
 
@@ -634,7 +638,38 @@ options, after which the object is frozen to prevent further modifications.
     <td>[packagePath]</td><td><code>string</code></td><td><p>Path to the package.json file (set during initialization)</p>
 </td>
     </tr><tr>
+    <td>[remoteDomain]</td><td><code>string</code></td><td><p>Domain to use if linkUrl is not provided (set during initialization)</p>
+</td>
+    </tr><tr>
     <td>[prPath]</td><td><code>string</code></td><td><p>Path segment for pull request links (set during initialization)</p>
+</td>
+    </tr>  </tbody>
+</table>
+
+<a name="module_Global..isUrl"></a>
+
+### Global~isUrl(str, [settings]) ⇒ <code>boolean</code>
+Confirm a value is a valid URL or URL-like.
+
+**Kind**: inner method of [<code>Global</code>](#module_Global)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Default</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>str</td><td><code>string</code></td><td></td><td><p>Confirm a string is a URL</p>
+</td>
+    </tr><tr>
+    <td>[settings]</td><td><code>object</code></td><td><code>{}</code></td><td><p>Configuration options</p>
+</td>
+    </tr><tr>
+    <td>[settings.allowedProtocols]</td><td><code>Array</code></td><td><code>[&#x27;http&#x27;, &#x27;https&#x27;]</code></td><td><p>List of allowed URL protocols.</p>
+</td>
+    </tr><tr>
+    <td>[settings.isStrict]</td><td><code>boolean</code></td><td><code>true</code></td><td><p>If <code>true</code>, only strict URL validation is performed.</p>
 </td>
     </tr>  </tbody>
 </table>

--- a/src/__tests__/__snapshots__/cmds.test.js.snap
+++ b/src/__tests__/__snapshots__/cmds.test.js.snap
@@ -15,10 +15,10 @@ exports[`Commands should attempt to run commands: commands 1`] = `
   },
   {
     "getLinkUrls": {
-      "baseUrl": undefined,
-      "commitUrl": undefined,
-      "compareUrl": undefined,
-      "prUrl": undefined,
+      "baseUrl": "https://undefined/<execSync>["git remote get-url origin"]</execSync>",
+      "commitUrl": false,
+      "compareUrl": false,
+      "prUrl": false,
     },
   },
   {

--- a/src/__tests__/__snapshots__/global.test.js.snap
+++ b/src/__tests__/__snapshots__/global.test.js.snap
@@ -83,6 +83,7 @@ exports[`Global should return specific properties: specific properties 1`] = `
       "value": "general",
     },
   },
+  "isUrl": [Function],
 }
 `;
 

--- a/src/__tests__/cmds.test.js
+++ b/src/__tests__/cmds.test.js
@@ -1,5 +1,6 @@
 const { join } = require('path');
 const cmds = require('../cmds');
+const { getLinkUrls } = cmds;
 const { OPTIONS } = require('../global');
 
 describe('Commands', () => {
@@ -67,5 +68,47 @@ describe('Commands', () => {
     );
 
     multiItemMockClear();
+  });
+});
+
+describe('getLinkUrls', () => {
+  it.each([
+    {
+      description: 'Standard GitHub HTTPS',
+      options: { linkUrl: 'https://github.com/user/repo', commitPath: 'commit', comparePath: 'compare', prPath: 'pull' },
+      expected: {
+        baseUrl: 'https://github.com/user/repo',
+        commitUrl: 'https://github.com/user/repo/commit/',
+        compareUrl: 'https://github.com/user/repo/compare/',
+        prUrl: 'https://github.com/user/repo/pull/'
+      }
+    },
+    {
+      description: 'Custom GitLab Domain',
+      options: {
+        linkUrl: 'https://gitlab.mycorp.com/group/project',
+        commitPath: '-/commit',
+        prPath: '-/merge_requests'
+      },
+      expected: {
+        baseUrl: 'https://gitlab.mycorp.com/group/project',
+        commitUrl: 'https://gitlab.mycorp.com/group/project/-/commit/',
+        prUrl: 'https://gitlab.mycorp.com/group/project/-/merge_requests/'
+      }
+    },
+    {
+      description: 'SSH override (Strict CLI Contract)',
+      options: { linkUrl: 'git@github.com:user/repo.git', remoteDomain: 'github.com' },
+      expected: {
+        baseUrl: undefined,
+        commitUrl: undefined,
+        compareUrl: undefined,
+        prUrl: undefined
+      }
+    }
+  ])('should handle correctly, $description', ({ options, expected }) => {
+    const result = getLinkUrls(options);
+
+    expect(result).toMatchObject(expected);
   });
 });

--- a/src/__tests__/global.test.js
+++ b/src/__tests__/global.test.js
@@ -1,4 +1,5 @@
 const global = require('../global');
+const { isUrl } = global;
 
 describe('Global', () => {
   it('should return specific properties', () => {
@@ -20,5 +21,35 @@ describe('Global', () => {
     OPTIONS.dolor = 'sit';
 
     expect({ isFrozen: Object.isFrozen(OPTIONS), OPTIONS }).toMatchSnapshot('immutable');
+  });
+});
+
+describe('isUrl', () => {
+  it.each([
+    { description: 'http', url: 'http://example.com' },
+    { description: 'https', url: 'https://example.com' },
+    { description: 'file', url: 'file:///path/to/file.txt' },
+    { description: 'node', url: 'node://path/to/file.txt' },
+    { description: 'data', url: 'data:text/plain;base64,1234567890==' }
+  ])('should validate $description', ({ url }) => {
+    expect(isUrl(url)).toBe(true);
+  });
+
+  it.each([
+    { description: 'invalid protocol', url: 'ftp://example.com' },
+    { description: 'random', url: 'random://example.com' },
+    { description: 'null', url: null },
+    { description: 'undefined', url: undefined }
+  ])('should fail, $description', ({ url }) => {
+    expect(isUrl(url)).toBe(false);
+  });
+
+  it.each([
+    { description: 'http allowed, strict', options: { isStrict: true, allowedProtocols: ['http'] }, expected: false },
+    { description: 'http allowed, not strict', options: { isStrict: false, allowedProtocols: ['http'] }, expected: true },
+    { description: 'ftp allowed, strict', options: { isStrict: true, allowedProtocols: ['ftp'] }, expected: true },
+    { description: 'ftp allowed, not strict', options: { isStrict: false, allowedProtocols: ['ftp'] }, expected: true }
+  ])('should handle allowedProtocols and strict options, $description', ({ options, expected }) => {
+    expect(isUrl('ftp://example.com', options)).toBe(expected);
   });
 });

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -1,8 +1,7 @@
 const { execSync } = require('child_process');
-const { join } = require('path');
 const semverClean = require('semver/functions/clean');
 const semverInc = require('semver/functions/inc');
-const { color, OPTIONS } = require('./global');
+const { color, isUrl, OPTIONS } = require('./global');
 
 /**
  * Functions for `git`, `package.json` version, and more
@@ -112,20 +111,30 @@ const getReleaseCommit = ({ releaseTypeScope, releaseBranch } = OPTIONS) => {
  * @param {string} options.comparePath - Path segment for comparison URLs (e.g., "compare")
  * @param {string} options.linkUrl - Optional explicit repository URL (falls back to git remote)
  * @param {string} options.prPath - Path segment for pull request URLs (e.g., "pull")
+ * @param {string} options.remoteDomain - Available remote domain for parsing if linkUrl is not provided.
  * @returns {{baseUrl: string, commitUrl: string, compareUrl: string, prUrl: string }}
  */
-const getLinkUrls = ({ commitPath, comparePath, linkUrl, prPath } = OPTIONS) => {
-  const setUrl = linkUrl || runCmd('git remote get-url origin', { errorMessage: 'Skipping remote path check... {0}' });
+const getLinkUrls = ({ commitPath, comparePath, linkUrl, prPath, remoteDomain } = OPTIONS) => {
+  let setUrl = linkUrl;
   let updatedUrl;
   let commitUrl;
   let compareUrl;
   let prUrl;
 
-  if (/^http/.test(setUrl)) {
+  if (!setUrl) {
+    setUrl = runCmd('git remote get-url origin', { errorMessage: 'Skipping remote path check... {0}' });
+
+    if (!isUrl(setUrl, { allowedProtocols: ['http', 'https'] })) {
+      setUrl = setUrl.split(remoteDomain).pop()?.replace(/^:/, '')?.replace(/^\//, '');
+      setUrl = `https://${remoteDomain}/${setUrl}`;
+    }
+  }
+
+  if (isUrl(setUrl, { allowedProtocols: ['http', 'https'] })) {
     updatedUrl = setUrl.trim().replace(/(\.git)$/, '');
     const [protocol, linkPath] = updatedUrl.split('://');
     const generateUrl = path => {
-      let tempUrl = typeof path === 'string' && `${protocol}://${join(linkPath, path)}`;
+      let tempUrl = typeof path === 'string' && `${protocol}://${linkPath.replace(/\/$/, '')}/${path}`;
 
       if (tempUrl && !/\/$/.test(tempUrl)) {
         tempUrl += '/';

--- a/src/global.js
+++ b/src/global.js
@@ -112,6 +112,42 @@ const conventionalCommitType = (types => {
 })(commitTypes.types);
 
 /**
+ * Confirm a value is a valid URL or URL-like.
+ *
+ * @param {string} str - Confirm a string is a URL
+ * @param {object} [settings={}] - Configuration options
+ * @param {Array} [settings.allowedProtocols=['http', 'https']] - List of allowed URL protocols.
+ * @param {boolean} [settings.isStrict=true] - If `true`, only strict URL validation is performed.
+ * @returns {boolean}
+ */
+const isUrl = (str, { allowedProtocols = ['file', 'http', 'https', 'data', 'node', 'git'], isStrict = true } = {}) => {
+  if (typeof str !== 'string' || !str.trim()) {
+    return false;
+  }
+
+  const isAllowed = allowedProtocols.some(type => str.toLowerCase().startsWith(`${type}:`));
+
+  // Strict and not allowed protocols
+  if (isStrict && !isAllowed) {
+    return false;
+  }
+
+  // Not strict and allowed protocols
+  if (!isStrict && isAllowed) {
+    return true;
+  }
+
+  // URL validation
+  try {
+    new URL(str);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Global configuration options for the changelog generator.
  *
  * This object stores all configuration options used throughout the application.
@@ -129,6 +165,7 @@ const conventionalCommitType = (types => {
  * @property {string} [linkUrl] - Base URL for repository links (set during initialization)
  * @property {string} [overrideVersion] - Version to use instead of a calculated version (set during initialization)
  * @property {string} [packagePath] - Path to the package.json file (set during initialization)
+ * @property {string} [remoteDomain] - Domain to use if linkUrl is not provided (set during initialization)
  * @property {string} [prPath] - Path segment for pull request links (set during initialization)
  */
 const OPTIONS = {
@@ -148,4 +185,4 @@ const OPTIONS = {
   }
 };
 
-module.exports = { color, contextPath, conventionalCommitType, generalCommitType, OPTIONS };
+module.exports = { color, contextPath, conventionalCommitType, generalCommitType, isUrl, OPTIONS };

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
-  "cmds.js:30:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
-  "cmds.js:256:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
-  "cmds.js:290:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:29:    console.error(color.RED, errorMessage.replace('{0}', e.message), color.NOCOLOR)",
+  "cmds.js:265:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
+  "cmds.js:299:    console.error(color.RED, \`Semver: \${e.message}\`, color.NOCOLOR)",
   "files.js:98:    console.info(\` \${updatedBody}\`)",
   "global.js:108:    console.error(color.RED, \`Conventional commit types: \${e.message}\`, color.NOCOLOR)",
   "index.js:57:    console.info( index.js:71:    console.info(color.NOCOLOR)",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- feat(cli): remote domain option

### Notes
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->
- replaces the biased domain check with an optional CLI flag for `remote-domain` defaulted to `github.com`

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->

<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
